### PR TITLE
test: 新增前後端完整測試套件與 CI 更新

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,7 +10,7 @@ on:
       - release
 
 jobs:
-  test:
+  backend-test:
     name: Backend Tests
     runs-on: ubuntu-latest
 
@@ -29,6 +29,29 @@ jobs:
         run: npm ci
         working-directory: backend
 
-      - name: Run tests
+      - name: Run backend tests
         run: npm test
         working-directory: backend
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run frontend tests
+        run: npm test
+        working-directory: frontend

--- a/backend/tests/routes/holidays.test.js
+++ b/backend/tests/routes/holidays.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+// ── Mocks（必須在 require 之前宣告，Jest 會提升至頂端）──────────────────────
+
+jest.mock('../../src/db/connect', () => ({
+  getIsDbConnected: jest.fn().mockReturnValue(true),
+  getHolidaysCollection: jest.fn(),
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  ensureConfigDocument: jest.fn(),
+  getDb: jest.fn(),
+}));
+
+jest.mock('../../src/services/holidayService', () => ({
+  holidaysCache: { clear: jest.fn(), delete: jest.fn() },
+  getWeekInfo: jest.fn(),
+  getHolidaysForYear: jest.fn(),
+  seedHolidays: jest.fn(),
+  refreshHolidaysFromCDN: jest.fn(),
+}));
+
+// ── 測試主體 ──────────────────────────────────────────────────────────────────
+
+const request = require('supertest');
+const app = require('../../server');
+const { getIsDbConnected, getHolidaysCollection } = require('../../src/db/connect');
+const { getWeekInfo, getHolidaysForYear, seedHolidays } = require('../../src/services/holidayService');
+
+/** 建立可覆寫欄位的 mock collection */
+const makeMockCol = (overrides = {}) => ({
+  find: jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) }),
+  deleteMany: jest.fn().mockResolvedValue({ deletedCount: 3 }),
+  countDocuments: jest.fn().mockResolvedValue(10),
+  updateOne: jest.fn().mockResolvedValue({}),
+  deleteOne: jest.fn().mockResolvedValue({}),
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getIsDbConnected.mockReturnValue(true);
+  getHolidaysCollection.mockReturnValue(makeMockCol());
+});
+
+// ── GET /api/holidays/:year ───────────────────────────────────────────────────
+
+describe('GET /api/holidays/:year', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).get('/api/holidays/2025');
+    expect(res.status).toBe(503);
+  });
+
+  it('回傳當年度假日清單（date/name 格式）', async () => {
+    getHolidaysCollection.mockReturnValue(
+      makeMockCol({
+        find: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            { _id: '2025-01-01', name: '元旦', isHoliday: true },
+          ]),
+        }),
+      })
+    );
+    const res = await request(app).get('/api/holidays/2025');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toEqual({ date: '2025-01-01', name: '元旦' });
+  });
+
+  it('DB 查詢失敗時回傳 500', async () => {
+    getHolidaysCollection.mockReturnValue(
+      makeMockCol({
+        find: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockRejectedValue(new Error('DB error')),
+        }),
+      })
+    );
+    const res = await request(app).get('/api/holidays/2025');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── POST /api/holidays/reseed ─────────────────────────────────────────────────
+
+describe('POST /api/holidays/reseed', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).post('/api/holidays/reseed');
+    expect(res.status).toBe(503);
+  });
+
+  it('成功重新植入後回傳 message 與 count', async () => {
+    seedHolidays.mockResolvedValue();
+    const res = await request(app).post('/api/holidays/reseed');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('message');
+    expect(res.body).toHaveProperty('count');
+    expect(seedHolidays).toHaveBeenCalled();
+  });
+
+  it('seedHolidays 失敗時回傳 500', async () => {
+    seedHolidays.mockRejectedValue(new Error('seed failed'));
+    const res = await request(app).post('/api/holidays/reseed');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── PUT /api/holidays ─────────────────────────────────────────────────────────
+
+describe('PUT /api/holidays', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app)
+      .put('/api/holidays')
+      .send({ date: '2025-01-01', name: '元旦', isHoliday: true });
+    expect(res.status).toBe(503);
+  });
+
+  it('缺少 date 欄位時回傳 400', async () => {
+    const res = await request(app).put('/api/holidays').send({ name: '元旦' });
+    expect(res.status).toBe(400);
+  });
+
+  it('isHoliday=true 時呼叫 updateOne（upsert）', async () => {
+    const col = makeMockCol();
+    getHolidaysCollection.mockReturnValue(col);
+    const res = await request(app)
+      .put('/api/holidays')
+      .send({ date: '2025-01-01', name: '元旦', isHoliday: true });
+    expect(res.status).toBe(200);
+    expect(col.updateOne).toHaveBeenCalled();
+    expect(col.deleteOne).not.toHaveBeenCalled();
+  });
+
+  it('isHoliday=false 時呼叫 deleteOne', async () => {
+    const col = makeMockCol();
+    getHolidaysCollection.mockReturnValue(col);
+    const res = await request(app)
+      .put('/api/holidays')
+      .send({ date: '2025-02-01', isHoliday: false });
+    expect(res.status).toBe(200);
+    expect(col.deleteOne).toHaveBeenCalled();
+    expect(col.updateOne).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET /api/holidays-in-range ────────────────────────────────────────────────
+
+describe('GET /api/holidays-in-range', () => {
+  it('缺少 startWeek 時回傳 400', async () => {
+    const res = await request(app).get('/api/holidays-in-range?numWeeks=1');
+    expect(res.status).toBe(400);
+  });
+
+  it('缺少 numWeeks 時回傳 400', async () => {
+    const res = await request(app).get('/api/holidays-in-range?startWeek=2025-W01');
+    expect(res.status).toBe(400);
+  });
+
+  it('正常回傳範圍內的假日清單', async () => {
+    getWeekInfo.mockReturnValue({
+      weekDates: ['2025-01-06', '2025-01-07', '2025-01-08', '2025-01-09', '2025-01-10'],
+    });
+    getHolidaysForYear.mockResolvedValue(new Map([['2025-01-06', '元旦補班']]));
+    const res = await request(app).get('/api/holidays-in-range?startWeek=2025-W01&numWeeks=1');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toContainEqual({ date: '2025-01-06', name: '元旦補班' });
+  });
+
+  it('範圍內無假日時回傳空陣列', async () => {
+    getWeekInfo.mockReturnValue({ weekDates: ['2025-03-10', '2025-03-11'] });
+    getHolidaysForYear.mockResolvedValue(new Map());
+    const res = await request(app).get('/api/holidays-in-range?startWeek=2025-W11&numWeeks=1');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/backend/tests/routes/profiles.test.js
+++ b/backend/tests/routes/profiles.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('../../src/db/connect', () => ({
+  getIsDbConnected: jest.fn().mockReturnValue(true),
+  getHolidaysCollection: jest.fn(),
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  ensureConfigDocument: jest.fn(),
+  getDb: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/profileRepository', () => ({
+  getConfig: jest.fn(),
+  setActiveProfile: jest.fn(),
+  createProfile: jest.fn(),
+  updateProfileSettings: jest.fn(),
+  renameProfile: jest.fn(),
+  deleteProfile: jest.fn(),
+  saveSchedule: jest.fn(),
+  getSchedule: jest.fn(),
+  deleteSchedule: jest.fn(),
+}));
+
+// ── 測試主體 ──────────────────────────────────────────────────────────────────
+
+const request = require('supertest');
+const app = require('../../server');
+const { getIsDbConnected } = require('../../src/db/connect');
+const repo = require('../../src/repositories/profileRepository');
+
+const minSettings = {
+  tasks: [{ name: '早班', count: 1 }],
+  personnel: [{ name: '張三' }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getIsDbConnected.mockReturnValue(true);
+});
+
+// ── GET /api/profiles ─────────────────────────────────────────────────────────
+
+describe('GET /api/profiles', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).get('/api/profiles');
+    expect(res.status).toBe(503);
+  });
+
+  it('回傳 repo.getConfig() 的結果', async () => {
+    const mockConfig = { activeProfile: 'default', profiles: { default: {} } };
+    repo.getConfig.mockResolvedValue(mockConfig);
+    const res = await request(app).get('/api/profiles');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockConfig);
+  });
+
+  it('config 為 null 時回傳空物件', async () => {
+    repo.getConfig.mockResolvedValue(null);
+    const res = await request(app).get('/api/profiles');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('repo 拋出例外時回傳 500', async () => {
+    repo.getConfig.mockRejectedValue(new Error('DB read error'));
+    const res = await request(app).get('/api/profiles');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── PUT /api/profiles/active ──────────────────────────────────────────────────
+
+describe('PUT /api/profiles/active', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).put('/api/profiles/active').send({ name: 'test' });
+    expect(res.status).toBe(503);
+  });
+
+  it('成功更新作用中設定檔', async () => {
+    repo.setActiveProfile.mockResolvedValue();
+    const res = await request(app).put('/api/profiles/active').send({ name: 'my-profile' });
+    expect(res.status).toBe(200);
+    expect(repo.setActiveProfile).toHaveBeenCalledWith('my-profile');
+  });
+});
+
+// ── POST /api/profiles ────────────────────────────────────────────────────────
+
+describe('POST /api/profiles', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).post('/api/profiles').send({ name: 'valid' });
+    expect(res.status).toBe(503);
+  });
+
+  it('名稱含特殊符號（/）時回傳 400', async () => {
+    const res = await request(app).post('/api/profiles').send({ name: 'a/b' });
+    expect(res.status).toBe(400);
+  });
+
+  it('名稱含空格時回傳 400', async () => {
+    const res = await request(app).post('/api/profiles').send({ name: 'hello world' });
+    expect(res.status).toBe(400);
+  });
+
+  it('合法名稱時回傳 201', async () => {
+    repo.createProfile.mockResolvedValue();
+    const res = await request(app).post('/api/profiles').send({ name: 'valid-profile' });
+    expect(res.status).toBe(201);
+  });
+
+  it('repo 拋出例外時回傳 500', async () => {
+    repo.createProfile.mockRejectedValue(new Error('already exists'));
+    const res = await request(app).post('/api/profiles').send({ name: 'valid' });
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── PUT /api/profiles/:name ───────────────────────────────────────────────────
+
+describe('PUT /api/profiles/:name', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).put('/api/profiles/test').send({ settings: minSettings });
+    expect(res.status).toBe(503);
+  });
+
+  it('settings 無效（tasks 非陣列）時回傳 400', async () => {
+    const res = await request(app)
+      .put('/api/profiles/test')
+      .send({ settings: { tasks: 'bad', personnel: [] } });
+    expect(res.status).toBe(400);
+  });
+
+  it('成功更新設定檔', async () => {
+    repo.updateProfileSettings.mockResolvedValue();
+    const res = await request(app).put('/api/profiles/test').send({ settings: minSettings });
+    expect(res.status).toBe(200);
+    expect(repo.updateProfileSettings).toHaveBeenCalled();
+  });
+
+  it('設定檔不存在時（status=404）回傳 404', async () => {
+    const err = Object.assign(new Error('找不到'), { status: 404 });
+    repo.updateProfileSettings.mockRejectedValue(err);
+    const res = await request(app).put('/api/profiles/test').send({ settings: minSettings });
+    expect(res.status).toBe(404);
+  });
+
+  it('中文名稱正確解碼後更新', async () => {
+    repo.updateProfileSettings.mockResolvedValue();
+    const encoded = encodeURIComponent('早班組');
+    const res = await request(app).put(`/api/profiles/${encoded}`).send({ settings: minSettings });
+    expect(res.status).toBe(200);
+    expect(repo.updateProfileSettings).toHaveBeenCalledWith('早班組', minSettings);
+  });
+});
+
+// ── PUT /api/profiles/:name/rename ────────────────────────────────────────────
+
+describe('PUT /api/profiles/:name/rename', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).put('/api/profiles/old/rename').send({ newName: 'new' });
+    expect(res.status).toBe(503);
+  });
+
+  it('新名稱含空格時回傳 400', async () => {
+    const res = await request(app)
+      .put('/api/profiles/valid/rename')
+      .send({ newName: 'a b' });
+    expect(res.status).toBe(400);
+  });
+
+  it('成功重新命名', async () => {
+    repo.renameProfile.mockResolvedValue();
+    const res = await request(app)
+      .put('/api/profiles/old-name/rename')
+      .send({ newName: 'new-name' });
+    expect(res.status).toBe(200);
+    expect(repo.renameProfile).toHaveBeenCalledWith('old-name', 'new-name');
+  });
+});
+
+// ── DELETE /api/profiles/:name ────────────────────────────────────────────────
+
+describe('DELETE /api/profiles/:name', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).delete('/api/profiles/test');
+    expect(res.status).toBe(503);
+  });
+
+  it('名稱含空格（URL 編碼後）時回傳 400', async () => {
+    const res = await request(app).delete(`/api/profiles/${encodeURIComponent('a b')}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('成功刪除設定檔', async () => {
+    repo.deleteProfile.mockResolvedValue();
+    const res = await request(app).delete('/api/profiles/test');
+    expect(res.status).toBe(200);
+    expect(repo.deleteProfile).toHaveBeenCalledWith('test');
+  });
+
+  it('repo 拋出 status=400 錯誤時轉發 400', async () => {
+    const err = Object.assign(new Error('無法刪除唯一設定檔'), { status: 400 });
+    repo.deleteProfile.mockRejectedValue(err);
+    const res = await request(app).delete('/api/profiles/test');
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/tests/routes/schedules.test.js
+++ b/backend/tests/routes/schedules.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('../../src/db/connect', () => ({
+  getIsDbConnected: jest.fn().mockReturnValue(true),
+  getHolidaysCollection: jest.fn(),
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  ensureConfigDocument: jest.fn(),
+  getDb: jest.fn(),
+}));
+
+jest.mock('../../src/repositories/profileRepository', () => ({
+  getConfig: jest.fn(),
+  setActiveProfile: jest.fn(),
+  createProfile: jest.fn(),
+  updateProfileSettings: jest.fn(),
+  renameProfile: jest.fn(),
+  deleteProfile: jest.fn(),
+  saveSchedule: jest.fn(),
+  getSchedule: jest.fn(),
+  deleteSchedule: jest.fn(),
+}));
+
+// ── 測試主體 ──────────────────────────────────────────────────────────────────
+
+const request = require('supertest');
+const app = require('../../server');
+const { getIsDbConnected } = require('../../src/db/connect');
+const repo = require('../../src/repositories/profileRepository');
+
+const sampleData = [{ week: 1, schedule: [], tasks: [], fillStats: [], dateRange: '2025-01-06~10' }];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  getIsDbConnected.mockReturnValue(true);
+  repo.getConfig.mockResolvedValue({ activeProfile: 'default' });
+});
+
+// ── POST /api/schedules ───────────────────────────────────────────────────────
+
+describe('POST /api/schedules', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: sampleData, profile: 'default' });
+    expect(res.status).toBe(503);
+  });
+
+  it('班表名稱超過 100 字元時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: 'a'.repeat(101), data: sampleData, profile: 'default' });
+    expect(res.status).toBe(400);
+  });
+
+  it('data 非陣列時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: 'bad', profile: 'default' });
+    expect(res.status).toBe(400);
+  });
+
+  it('data 為空陣列時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: [], profile: 'default' });
+    expect(res.status).toBe(400);
+  });
+
+  it('成功儲存班表，回傳 201', async () => {
+    repo.saveSchedule.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: sampleData, profile: 'default' });
+    expect(res.status).toBe(201);
+    expect(repo.saveSchedule).toHaveBeenCalledWith('default', '2025-W01', sampleData);
+  });
+
+  it('未提供 profile 時從 repo.getConfig() 取得', async () => {
+    repo.saveSchedule.mockResolvedValue();
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: sampleData });
+    expect(res.status).toBe(201);
+    expect(repo.getConfig).toHaveBeenCalled();
+    expect(repo.saveSchedule).toHaveBeenCalledWith('default', '2025-W01', sampleData);
+  });
+
+  it('提供無效 profile 名稱時回傳 400', async () => {
+    const res = await request(app)
+      .post('/api/schedules')
+      .send({ name: '2025-W01', data: sampleData, profile: 'a b' });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── GET /api/schedules/:name ──────────────────────────────────────────────────
+
+describe('GET /api/schedules/:name', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).get('/api/schedules/2025-W01');
+    expect(res.status).toBe(503);
+  });
+
+  it('班表名稱超過 100 字元時回傳 400', async () => {
+    const name = encodeURIComponent('a'.repeat(101));
+    const res = await request(app).get(`/api/schedules/${name}`);
+    expect(res.status).toBe(400);
+  });
+
+  it('成功取得班表', async () => {
+    repo.getSchedule.mockResolvedValue(sampleData);
+    const res = await request(app).get('/api/schedules/2025-W01');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(sampleData);
+  });
+
+  it('班表不存在時回傳 404', async () => {
+    repo.getSchedule.mockResolvedValue(null);
+    const res = await request(app).get('/api/schedules/not-exist');
+    expect(res.status).toBe(404);
+  });
+
+  it('中文班表名稱正確解碼後查詢', async () => {
+    repo.getSchedule.mockResolvedValue(sampleData);
+    const encoded = encodeURIComponent('春季排班');
+    const res = await request(app).get(`/api/schedules/${encoded}`);
+    expect(res.status).toBe(200);
+    expect(repo.getSchedule).toHaveBeenCalledWith('default', '春季排班');
+  });
+});
+
+// ── DELETE /api/schedules/:name ───────────────────────────────────────────────
+
+describe('DELETE /api/schedules/:name', () => {
+  it('DB 未連線時回傳 503', async () => {
+    getIsDbConnected.mockReturnValue(false);
+    const res = await request(app).delete('/api/schedules/2025-W01');
+    expect(res.status).toBe(503);
+  });
+
+  it('成功刪除班表', async () => {
+    repo.deleteSchedule.mockResolvedValue();
+    const res = await request(app).delete('/api/schedules/2025-W01');
+    expect(res.status).toBe(200);
+    expect(repo.deleteSchedule).toHaveBeenCalledWith('default', '2025-W01');
+  });
+
+  it('repo 拋出例外時回傳 500', async () => {
+    repo.deleteSchedule.mockRejectedValue(new Error('DB error'));
+    const res = await request(app).delete('/api/schedules/2025-W01');
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,215 @@
       "name": "schedule-v2-frontend",
       "version": "1.0.0",
       "devDependencies": {
-        "vite": "^5.0.0"
+        "jsdom": "^29.1.1",
+        "vite": "^5.0.0",
+        "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -402,6 +610,31 @@
         "node": ">=12"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -759,6 +992,259 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -798,6 +1284,26 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -812,6 +1318,109 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",
@@ -830,6 +1439,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -866,6 +1505,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -913,6 +1572,26 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -923,12 +1602,134 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -982,6 +1783,177 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,9 +5,13 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "vite": "^5.0.0"
+    "jsdom": "^29.1.1",
+    "vite": "^5.0.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/frontend/src/features/schedule/diffSummary.test.js
+++ b/frontend/src/features/schedule/diffSummary.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { buildDiff } from './diffSummary.js';
+
+// ── 測試資料工廠 ─────────────────────────────────────────────────────────────
+
+const makeScheduleDays = (flags = [true, true, true, true, true]) =>
+  flags.map((shouldSchedule) => ({ shouldSchedule }));
+
+/** 建立 dayCount × taskCount 的班表，每個 slot 填入 people 的副本 */
+const makeSchedule = (people, taskCount = 1, dayCount = 5) =>
+  Array.from({ length: dayCount }, () =>
+    Array.from({ length: taskCount }, () => [...people])
+  );
+
+const baseWeek = () => ({
+  dateRange: '2025-01-06~10',
+  tasks: [{ name: '早班' }],
+  scheduleDays: makeScheduleDays(),
+  schedule: makeSchedule(['張三']),
+});
+
+const clone = (obj) => JSON.parse(JSON.stringify(obj));
+
+// ── buildDiff ────────────────────────────────────────────────────────────────
+
+describe('buildDiff', () => {
+  it('無變更時回傳空陣列', () => {
+    const week = baseWeek();
+    expect(buildDiff([week], [clone(week)])).toHaveLength(0);
+  });
+
+  it('新增人員時 added 包含該人員', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    current[0].schedule[0][0] = ['張三', '李四'];
+    const changes = buildDiff(original, current);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].added).toContain('李四');
+    expect(changes[0].removed).toHaveLength(0);
+  });
+
+  it('移除人員時 removed 包含該人員', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    current[0].schedule[0][0] = [];
+    const changes = buildDiff(original, current);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].removed).toContain('張三');
+    expect(changes[0].added).toHaveLength(0);
+  });
+
+  it('同時有新增與移除時 added/removed 均正確', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    current[0].schedule[0][0] = ['李四']; // replace 張三 with 李四
+    const [change] = buildDiff(original, current);
+    expect(change.added).toContain('李四');
+    expect(change.removed).toContain('張三');
+  });
+
+  it('休假日（shouldSchedule=false）跳過，不計入差異', () => {
+    const original = [baseWeek()];
+    original[0].scheduleDays[0].shouldSchedule = false;
+    const current = clone(original);
+    current[0].schedule[0][0] = ['李四']; // different person, but off day
+    expect(buildDiff(original, current)).toHaveLength(0);
+  });
+
+  it('多週時各週差異分別回報', () => {
+    const week1 = baseWeek();
+    const week2 = { ...baseWeek(), dateRange: '2025-01-13~17' };
+    const original = [week1, week2];
+    const current = clone(original);
+    current[0].schedule[0][0] = [];               // week 1, day 0: remove 張三
+    current[1].schedule[0][0] = ['張三', '王五']; // week 2, day 0: add 王五
+    const changes = buildDiff(original, current);
+    expect(changes).toHaveLength(2);
+  });
+
+  it('label 包含正確週次、日期範圍、星期、勤務名稱', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    current[0].schedule[0][0] = [];
+    const [change] = buildDiff(original, current);
+    expect(change.label).toContain('第 1 週');
+    expect(change.label).toContain('2025-01-06~10');
+    expect(change.label).toContain('週一');
+    expect(change.label).toContain('早班');
+  });
+
+  it('第二週的 label 包含「第 2 週」', () => {
+    const week2 = { ...baseWeek(), dateRange: '2025-01-13~17' };
+    const original = [baseWeek(), week2];
+    const current = clone(original);
+    current[1].schedule[0][0] = [];
+    const changes = buildDiff(original, current);
+    const week2Changes = changes.filter((c) => c.label.includes('第 2 週'));
+    expect(week2Changes).toHaveLength(1);
+  });
+
+  it('多勤務時依勤務 index 區分，label 含正確勤務名稱', () => {
+    const twoTaskWeek = {
+      dateRange: '2025-01-06~10',
+      tasks: [{ name: '早班' }, { name: '午班' }],
+      scheduleDays: makeScheduleDays(),
+      schedule: makeSchedule(['張三'], 2),
+    };
+    const original = [twoTaskWeek];
+    const current = clone(original);
+    current[0].schedule[0][1] = []; // day 0, task 1 (午班): remove 張三
+    const changes = buildDiff(original, current);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].label).toContain('午班');
+  });
+
+  it('週三（index 2）的 label 包含「週三」', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    current[0].schedule[2][0] = []; // Wednesday
+    const [change] = buildDiff(original, current);
+    expect(change.label).toContain('週三');
+  });
+
+  it('current 對應 slot 缺失時視為空 slot（removed 全部原人員）', () => {
+    const original = [baseWeek()];
+    const current = clone(original);
+    // Simulate missing task slot by setting it to undefined
+    current[0].schedule[0][0] = undefined;
+    const changes = buildDiff(original, current);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].removed).toContain('張三');
+  });
+});

--- a/frontend/src/state/draftManager.test.js
+++ b/frontend/src/state/draftManager.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  setEditingData,
+  setGeneratedData,
+  setCurrentScheduleName,
+  setAppState,
+  getAppState,
+} from './appState.js';
+import { autoSaveDraft, clearDraft } from './draftManager.js';
+
+// ── 環境設定 ─────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.useFakeTimers();
+  setEditingData(null);
+  setGeneratedData(null);
+  setCurrentScheduleName(null);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  localStorage.clear();
+});
+
+// ── autoSaveDraft ─────────────────────────────────────────────────────────────
+
+describe('autoSaveDraft', () => {
+  it('editingData 為 null 時計時器觸發後不寫入 localStorage', () => {
+    setEditingData(null);
+    autoSaveDraft();
+    vi.runAllTimers();
+    expect(localStorage.getItem('schedule_draft')).toBeNull();
+  });
+
+  it('editingData 存在時 2 秒後寫入 schedule_draft', () => {
+    setEditingData([{ week: 1 }]);
+    setGeneratedData([{ week: 0 }]);
+    setCurrentScheduleName('排班-2025');
+    autoSaveDraft();
+    expect(localStorage.getItem('schedule_draft')).toBeNull(); // 尚未觸發
+    vi.runAllTimers();
+    const raw = localStorage.getItem('schedule_draft');
+    expect(raw).not.toBeNull();
+    const draft = JSON.parse(raw);
+    expect(draft.editingData).toEqual([{ week: 1 }]);
+    expect(draft.scheduleName).toBe('排班-2025');
+    expect(draft.generatedData).toEqual([{ week: 0 }]);
+    expect(draft).toHaveProperty('savedAt');
+    expect(draft).toHaveProperty('profile');
+  });
+
+  it('儲存的 profile 來自 appState.activeProfile', () => {
+    setAppState({ activeProfile: 'my-team' });
+    setEditingData([{ w: 1 }]);
+    autoSaveDraft();
+    vi.runAllTimers();
+    const draft = JSON.parse(localStorage.getItem('schedule_draft'));
+    expect(draft.profile).toBe('my-team');
+  });
+
+  it('多次連續呼叫只執行一次儲存（debounce）', () => {
+    setEditingData([{ week: 1 }]);
+    autoSaveDraft();
+    autoSaveDraft();
+    autoSaveDraft();
+    vi.runAllTimers();
+    // 只有一筆 draft 被寫入
+    expect(localStorage.getItem('schedule_draft')).not.toBeNull();
+    const draft = JSON.parse(localStorage.getItem('schedule_draft'));
+    expect(draft.editingData).toEqual([{ week: 1 }]);
+  });
+
+  it('儲存的 savedAt 是數字（Unix timestamp）', () => {
+    setEditingData([{ w: 1 }]);
+    autoSaveDraft();
+    vi.runAllTimers();
+    const draft = JSON.parse(localStorage.getItem('schedule_draft'));
+    expect(typeof draft.savedAt).toBe('number');
+  });
+});
+
+// ── clearDraft ────────────────────────────────────────────────────────────────
+
+describe('clearDraft', () => {
+  it('清除 localStorage 中的 schedule_draft', () => {
+    localStorage.setItem('schedule_draft', JSON.stringify({ test: true }));
+    clearDraft();
+    expect(localStorage.getItem('schedule_draft')).toBeNull();
+  });
+
+  it('沒有 draft 時呼叫不報錯', () => {
+    expect(() => clearDraft()).not.toThrow();
+  });
+
+  it('取消尚未觸發的 autoSaveDraft 計時器', () => {
+    setEditingData([{ week: 1 }]);
+    autoSaveDraft();    // 計時器已排程
+    clearDraft();       // 應取消計時器並清除 draft
+    vi.runAllTimers();  // 計時器不再觸發
+    expect(localStorage.getItem('schedule_draft')).toBeNull();
+  });
+});

--- a/frontend/src/state/historyStack.test.js
+++ b/frontend/src/state/historyStack.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setEditingData, getEditingData } from './appState.js';
+import {
+  pushEditHistory,
+  undoEdit,
+  redoEdit,
+  clearEditHistory,
+  getHistoryLock,
+  setHistoryLock,
+} from './historyStack.js';
+
+// ── 重置模組層級狀態 ────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  clearEditHistory();
+  setHistoryLock(false);
+  setEditingData(null);
+});
+
+// ── pushEditHistory ──────────────────────────────────────────────────────────
+
+describe('pushEditHistory', () => {
+  it('editingData 為 null 時不推入堆疊', () => {
+    setEditingData(null);
+    pushEditHistory();
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('historyLock 為 true 時不推入堆疊', () => {
+    setEditingData([{ week: 1 }]);
+    setHistoryLock(true);
+    pushEditHistory();
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('正常狀態下推入 editingData 的深複製快照', () => {
+    setEditingData([{ week: 1 }]);
+    pushEditHistory();
+    setEditingData([{ week: 2 }]);
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(getEditingData()).toEqual([{ week: 1 }]);
+  });
+
+  it('push 後清空 redoStack', () => {
+    setEditingData([{ v: 'a' }]);
+    pushEditHistory();
+    setEditingData([{ v: 'b' }]);
+    undoEdit(vi.fn()); // redoStack now has [{v:'b'}]
+    setEditingData([{ v: 'c' }]);
+    pushEditHistory(); // should clear redo
+    const cb = vi.fn();
+    redoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('超過 MAX_HISTORY(20) 時移除最舊快照，堆疊維持 20 筆', () => {
+    for (let i = 0; i < 22; i++) {
+      setEditingData([{ n: i }]);
+      pushEditHistory();
+    }
+    setEditingData([{ n: 22 }]);
+    let count = 0;
+    const cb = vi.fn(() => count++);
+    for (let i = 0; i < 25; i++) undoEdit(cb);
+    expect(count).toBe(20);
+  });
+});
+
+// ── undoEdit ─────────────────────────────────────────────────────────────────
+
+describe('undoEdit', () => {
+  it('堆疊為空時不呼叫 renderCallback', () => {
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('執行後 editingData 回到上一個快照', () => {
+    setEditingData([{ step: 1 }]);
+    pushEditHistory();
+    setEditingData([{ step: 2 }]);
+    undoEdit(vi.fn());
+    expect(getEditingData()).toEqual([{ step: 1 }]);
+  });
+
+  it('執行後呼叫 renderCallback 一次', () => {
+    setEditingData([{ step: 1 }]);
+    pushEditHistory();
+    setEditingData([{ step: 2 }]);
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('執行後將目前狀態推入 redoStack，redo 可恢復', () => {
+    setEditingData([{ step: 1 }]);
+    pushEditHistory();
+    setEditingData([{ step: 2 }]);
+    undoEdit(vi.fn()); // editing → step1, redo has step2
+    redoEdit(vi.fn()); // editing → step2 again
+    expect(getEditingData()).toEqual([{ step: 2 }]);
+  });
+
+  it('連續多次 undo 依序恢復歷史', () => {
+    setEditingData([{ n: 1 }]); pushEditHistory();
+    setEditingData([{ n: 2 }]); pushEditHistory();
+    setEditingData([{ n: 3 }]);
+    undoEdit(vi.fn());
+    expect(getEditingData()).toEqual([{ n: 2 }]);
+    undoEdit(vi.fn());
+    expect(getEditingData()).toEqual([{ n: 1 }]);
+  });
+});
+
+// ── redoEdit ──────────────────────────────────────────────────────────────────
+
+describe('redoEdit', () => {
+  it('redoStack 為空時不呼叫 renderCallback', () => {
+    const cb = vi.fn();
+    redoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('執行後 editingData 恢復至 redo 快照', () => {
+    setEditingData([{ v: 'a' }]); pushEditHistory();
+    setEditingData([{ v: 'b' }]);
+    undoEdit(vi.fn());
+    redoEdit(vi.fn());
+    expect(getEditingData()).toEqual([{ v: 'b' }]);
+  });
+
+  it('執行後呼叫 renderCallback 一次', () => {
+    setEditingData([{ v: 'a' }]); pushEditHistory();
+    setEditingData([{ v: 'b' }]);
+    undoEdit(vi.fn());
+    const cb = vi.fn();
+    redoEdit(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('redo 後再 undo 可再次回到前一狀態', () => {
+    setEditingData([{ v: 'a' }]); pushEditHistory();
+    setEditingData([{ v: 'b' }]);
+    undoEdit(vi.fn()); // → a
+    redoEdit(vi.fn()); // → b
+    undoEdit(vi.fn()); // → a again
+    expect(getEditingData()).toEqual([{ v: 'a' }]);
+  });
+});
+
+// ── clearEditHistory ──────────────────────────────────────────────────────────
+
+describe('clearEditHistory', () => {
+  it('清空後 undoEdit 不觸發 callback', () => {
+    setEditingData([{ x: 1 }]); pushEditHistory();
+    clearEditHistory();
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('清空後 redoEdit 不觸發 callback', () => {
+    setEditingData([{ x: 1 }]); pushEditHistory();
+    setEditingData([{ x: 2 }]);
+    undoEdit(vi.fn()); // populate redo
+    clearEditHistory();
+    const cb = vi.fn();
+    redoEdit(cb);
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+// ── setHistoryLock / getHistoryLock ───────────────────────────────────────────
+
+describe('getHistoryLock / setHistoryLock', () => {
+  it('預設為 false', () => {
+    expect(getHistoryLock()).toBe(false);
+  });
+
+  it('setHistoryLock(true) 後 getHistoryLock() 回傳 true', () => {
+    setHistoryLock(true);
+    expect(getHistoryLock()).toBe(true);
+  });
+
+  it('setHistoryLock(false) 後可正常 push', () => {
+    setHistoryLock(true);
+    setHistoryLock(false);
+    setEditingData([{ v: 1 }]);
+    pushEditHistory();
+    setEditingData([{ v: 2 }]);
+    const cb = vi.fn();
+    undoEdit(cb);
+    expect(cb).toHaveBeenCalled();
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,4 +6,8 @@ export default defineConfig({
       '/api': 'http://localhost:3000',
     },
   },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary

- 安裝 Vitest + jsdom，前端新增 3 個測試檔（38 個測試）：`diffSummary`、`historyStack`、`draftManager`
- 後端新增 3 個路由模擬測試檔（+52 個），用 `jest.mock` 隔離 DB，覆蓋 holidays / profiles / schedules API
- CI workflow 拆成 `backend-test` 和 `frontend-test` 兩個平行 job，往後 PR 兩邊都會自動驗證

## Test plan

- [x] 後端 136/136 通過（`cd backend && npm test`）
- [x] 前端 38/38 通過（`cd frontend && npm test`）
- [x] GitHub Actions 兩個 job 均為綠燈