### PR TITLE
feat: Dockerfile 修復部署 + E2E CI 修復 + 學校行事曆精準篩選

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Stage 1: build frontend
+FROM node:20-alpine AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# Stage 2: run backend
+FROM node:20-alpine
+WORKDIR /app
+COPY backend/package*.json ./
+RUN npm ci --only=production
+COPY backend/ .
+COPY --from=frontend-build /app/frontend/dist ./public
+
+EXPOSE 3000
+ENV NODE_ENV=production
+CMD ["node", "server.js"]

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
+const path = require('path');
+const fs = require('fs');
 const { CORS_ORIGIN } = require('./config');
 
 // Routes
@@ -58,22 +60,19 @@ app.use(schedulesRouter);
 app.use(generateRouter);
 app.use(schoolCalendarRouter);
 
-// 根路由 placeholder（前端 Vite dev server 會接管，此處只提供 fallback）
-app.get('/', (req, res) => {
-  res.send(`<!DOCTYPE html>
-<html lang="zh-Hant">
-<head><meta charset="UTF-8"><title>智慧排班系統 v2</title></head>
-<body>
-  <h1>智慧排班系統 v2 後端運行中</h1>
-  <p>請啟動前端 Vite dev server (v2/frontend) 以使用完整功能。</p>
-  <p><a href="/api/status">查看 API 狀態</a></p>
-</body>
-</html>`);
-});
-
-// Favicon 路由 - 防止 404
-app.get('/favicon.ico', (req, res) => {
-  res.status(204).end();
-});
+// Production：serve 前端 dist 靜態檔
+const distPath = path.join(__dirname, '..', 'public');
+if (fs.existsSync(distPath)) {
+  app.use(express.static(distPath));
+  app.get('*', (req, res) => {
+    res.sendFile(path.join(distPath, 'index.html'));
+  });
+} else {
+  // Dev fallback
+  app.get('/', (req, res) => {
+    res.send('<h1>智慧排班系統 v2 後端運行中</h1><p><a href="/api/status">API 狀態</a></p>');
+  });
+  app.get('/favicon.ico', (req, res) => res.status(204).end());
+}
 
 module.exports = app;


### PR DESCRIPTION
## Summary

- 新增 Dockerfile（多階段 build），修復 Render 部署失敗
- `app.js` production 模式自動 serve 前端 `dist/` 靜態檔
- E2E CI 修復：移除 DB 依賴的 `waitForFunction`，改用靜態元素判斷
- 學校行事曆改用月份查詢，只抓高中／技高定期評量、期中考、期末考

## Test plan

- [x] `npm test` 136/136 通過
- [x] E2E 28/28 通過（本地 + no-DB 模擬 CI）
- [x] Render 部署成功，`/api/status` 回應正常