### PR TITLE
fix: 加入 holidays/ 目錄至 Docker 映像，修正假日 reseed 後 count=0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 COPY backend/package*.json ./
 RUN npm ci --only=production
 COPY backend/ .
+COPY holidays/ ./holidays/
 COPY --from=frontend-build /app/frontend/dist ./public
 
 EXPOSE 3000


### PR DESCRIPTION
## Summary

- Dockerfile 的 Stage 2 缺少 `COPY holidays/ ./holidays/`
- 導致 `POST /api/holidays/reseed` 呼叫 `seedHolidays()` 時找不到 JSON 檔案，回傳 `count=0`
- 修正後重新部署，再呼叫一次 reseed 即可補入假日資料

## Test plan

- [ ] Render 重新部署後，呼叫 `POST /api/holidays/reseed`，確認 `count > 0`
- [ ] 前端產生班表，確認假日（如元旦、春節）正確顯示為灰色