### PR TITLE
fix: reseed 改從 CDN 抓最新假日資料

### DIFF
--- a/backend/src/routes/holidays.js
+++ b/backend/src/routes/holidays.js
@@ -5,7 +5,6 @@ const {
   holidaysCache,
   getWeekInfo,
   getHolidaysForYear,
-  seedHolidays,
 } = require('../services/holidayService');
 
 const debugDb = debug('app:db');
@@ -34,7 +33,9 @@ router.post('/api/holidays/reseed', async (req, res) => {
     const deleteResult = await getHolidaysCollection().deleteMany({});
     debugDb(`已刪除 ${deleteResult.deletedCount} 筆舊假日資料。`);
     holidaysCache.clear();
-    await seedHolidays();
+    const currentYear = new Date().getFullYear();
+    const years = [currentYear - 1, currentYear, currentYear + 1];
+    await Promise.all(years.map((year) => getHolidaysForYear(year)));
     const count = await getHolidaysCollection().countDocuments();
     res.json({ message: '假日資料重新植入完成', count });
   } catch (error) {

--- a/backend/tests/routes/holidays.test.js
+++ b/backend/tests/routes/holidays.test.js
@@ -26,7 +26,7 @@ jest.mock('../../src/services/holidayService', () => ({
 const request = require('supertest');
 const app = require('../../server');
 const { getIsDbConnected, getHolidaysCollection } = require('../../src/db/connect');
-const { getWeekInfo, getHolidaysForYear, seedHolidays } = require('../../src/services/holidayService');
+const { getWeekInfo, getHolidaysForYear } = require('../../src/services/holidayService');
 
 /** 建立可覆寫欄位的 mock collection */
 const makeMockCol = (overrides = {}) => ({
@@ -92,16 +92,16 @@ describe('POST /api/holidays/reseed', () => {
   });
 
   it('成功重新植入後回傳 message 與 count', async () => {
-    seedHolidays.mockResolvedValue();
+    getHolidaysForYear.mockResolvedValue(new Map());
     const res = await request(app).post('/api/holidays/reseed');
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('message');
     expect(res.body).toHaveProperty('count');
-    expect(seedHolidays).toHaveBeenCalled();
+    expect(getHolidaysForYear).toHaveBeenCalled();
   });
 
-  it('seedHolidays 失敗時回傳 500', async () => {
-    seedHolidays.mockRejectedValue(new Error('seed failed'));
+  it('getHolidaysForYear 失敗時回傳 500', async () => {
+    getHolidaysForYear.mockRejectedValue(new Error('fetch failed'));
     const res = await request(app).post('/api/holidays/reseed');
     expect(res.status).toBe(500);
   });


### PR DESCRIPTION
## Summary

- `POST /api/holidays/reseed` 原本呼叫 `seedHolidays()`，讀本地 JSON 檔（且 Docker 容器內沒有這些檔案）
- 改為直接呼叫 `getHolidaysForYear()` 從 CDN 抓 2025/2026/2027 最新資料寫入 MongoDB
- 更新對應測試

## Test plan

- [x] Render 重新部署後呼叫 `POST /api/holidays/reseed`，確認 `count > 0`
- [x] 前端班表假日正確顯示