### PR TITLE
feat: UI 設計統一、深色模式修正、學校行事曆快取、Dockerfile

### DIFF
--- a/backend/src/services/scheduleRenderer.js
+++ b/backend/src/services/scheduleRenderer.js
@@ -10,87 +10,90 @@ const escapeHtml = (unsafe) => {
 };
 
 const generateScheduleHtml = (fullScheduleData) => {
-  // 加入 A4 直式版面的 CSS
   let html = `
 <style>
 @media print {
-    @page {
-        size: A4 portrait;
-        margin: 10mm;
-    }
-    body {
-        width: 210mm;
-        min-height: 297mm;
-    }
+    @page { size: A4 portrait; margin: 10mm; }
+    body { width: 210mm; min-height: 297mm; }
+    .week-block { break-inside: avoid; }
 }
 </style>
 `;
 
   fullScheduleData.forEach((data, index) => {
-    const { schedule, tasks, dateRange, weekDayDates, scheduleDays, color } = data;
+    const { schedule, tasks, dateRange, weekDayDates, scheduleDays } = data;
     const weekDayNames = ['一', '二', '三', '四', '五'];
-    // 驗證並清理顏色值（防止 CSS 注入）
-    const safeHeaderColor = /^#[0-9a-fA-F]{6}$/.test(color.header) ? color.header : '#0284c7';
-    const headerStyle = `style="background-color: ${safeHeaderColor}; color: white;"`;
+
+    const workDays = scheduleDays.filter((d) => d.shouldSchedule).length;
+    const demand = tasks.reduce((s, t) => s + t.count, 0) * workDays;
+    const filled = tasks.reduce((s, task, ti) =>
+      s + scheduleDays.reduce((a, day, di) =>
+        a + (day.shouldSchedule ? schedule[di][ti].length : 0), 0), 0);
+    const pct = demand > 0 ? Math.round(filled / demand * 100) : 100;
+    const fillClass = pct >= 100 ? 'ok' : 'warn';
+
+    const theadCols = weekDayDates.map((date, i) =>
+      `<th><span class="dow">星期${weekDayNames[i]}</span><span class="date">${escapeHtml(date)}</span></th>`
+    ).join('');
+
+    const tbodyRows = tasks.map((task, taskIndex) => {
+      const maxPersonnel = Math.max(
+        ...weekDayDates.map((_, dayIndex) =>
+          scheduleDays[dayIndex].shouldSchedule ? schedule[dayIndex][taskIndex].length : 0
+        ),
+        1
+      );
+      const priorityCls = `p${task.priority || 9}`;
+      let rows = '';
+      for (let pi = 0; pi < maxPersonnel; pi++) {
+        rows += '<tr>';
+        if (pi === 0) {
+          rows += `<td class="task-cell" rowspan="${maxPersonnel}">
+            <span class="priority-dot ${priorityCls}"></span>${escapeHtml(task.name)}
+            <span class="task-meta">需 ${task.count} · P${task.priority || 9}</span>
+          </td>`;
+        }
+        weekDayDates.forEach((_, dayIndex) => {
+          if (!scheduleDays[dayIndex].shouldSchedule) {
+            if (pi === 0) {
+              rows += `<td class="holiday-cell" rowspan="${maxPersonnel}">
+                <span class="holiday-label">${escapeHtml(scheduleDays[dayIndex].description)}</span>
+              </td>`;
+            }
+          } else {
+            const personName = schedule[dayIndex][taskIndex][pi] || '';
+            if (personName) {
+              rows += `<td><div class="persons"><span class="person-tag">${escapeHtml(personName)}</span></div></td>`;
+            } else {
+              rows += `<td class="warn-cell"><div class="persons"><span class="person-tag unfilled">＋ 待補</span></div></td>`;
+            }
+          }
+        });
+        rows += '</tr>';
+      }
+      return rows;
+    }).join('');
 
     html += `
-            <div class="mb-8" id="schedule-week-${index}">
-                <h3 class="text-xl font-bold mb-2">第 ${index + 1} 週班表 (${escapeHtml(dateRange)})</h3>
-                <table class="schedule-table">
-                    <thead>
-                        <tr>
-                            <th ${headerStyle}>勤務地點</th>
-                            ${weekDayDates
-                              .map(
-                                (date, i) =>
-                                  `<th ${headerStyle}>星期${weekDayNames[i]}<br>(${escapeHtml(date)})</th>`
-                              )
-                              .join('')}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        ${tasks
-                          .map((task, taskIndex) => {
-                            // 計算這個任務在整週中最多有幾位員工（決定需要幾列）
-                            const maxPersonnel = Math.max(
-                              ...weekDayDates.map((_, dayIndex) =>
-                                scheduleDays[dayIndex].shouldSchedule
-                                  ? schedule[dayIndex][taskIndex].length
-                                  : 0
-                              ),
-                              1 // 至少一列
-                            );
-
-                            let taskRows = '';
-                            for (let personIndex = 0; personIndex < maxPersonnel; personIndex++) {
-                              taskRows += '<tr>';
-
-                              if (personIndex === 0) {
-                                taskRows += `<td class="font-medium align-middle" rowspan="${maxPersonnel}">${escapeHtml(task.name)}</td>`;
-                              }
-
-                              weekDayDates.forEach((_, dayIndex) => {
-                                if (!scheduleDays[dayIndex].shouldSchedule) {
-                                  if (personIndex === 0) {
-                                    taskRows += `<td class="holiday-cell align-middle" rowspan="${maxPersonnel}">${escapeHtml(scheduleDays[dayIndex].description)}</td>`;
-                                  }
-                                } else {
-                                  const personnel = schedule[dayIndex][taskIndex];
-                                  const personName = personnel[personIndex] || '';
-                                  taskRows += `<td class="align-middle">${escapeHtml(personName)}</td>`;
-                                }
-                              });
-
-                              taskRows += '</tr>';
-                            }
-                            return taskRows;
-                          })
-                          .join('')}
-                    </tbody>
-                </table>
-            </div>
-        `;
+<div class="week-block" id="schedule-week-${index}">
+  <div class="week-head">
+    <div class="week-label">
+      <span class="week-num">W${index + 1}</span>
+      <span class="week-date">${escapeHtml(dateRange)}</span>
+    </div>
+    <div class="week-stats">填補 <span class="${fillClass}">${filled}/${demand}</span> · ${pct}%</div>
+  </div>
+  <table class="s-table">
+    <thead><tr>
+      <th style="text-align:left; padding-left: 16px;">勤務</th>
+      ${theadCols}
+    </tr></thead>
+    <tbody>${tbodyRows}</tbody>
+  </table>
+</div>
+`;
   });
+
   return html;
 };
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,374 +1,1574 @@
 <!DOCTYPE html>
 <html lang="zh-Hant" class="">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>智慧排班系統</title>
-    <script>
-        tailwind = { config: { darkMode: 'class' } };
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdn.sheetjs.com/xlsx-0.20.1/package/dist/xlsx.full.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;700&display=swap" rel="stylesheet">
-    <style>
-        :root {
-            --bg-light: #f9fafb;
-            --text-light: #000000;
-            --card-bg-light: #ffffff;
-            --muted-text-light: #6b7280;
-            --border-light: #e5e7eb;
-            --input-bg-light: #f3f4f6;
-            --primary-color: #3b82f6;
-            --primary-hover: #2563eb;
-            --danger-color: #ef4444;
-            --danger-hover: #dc2626;
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>智慧排班系統</title>
+<script>
+  tailwind = { config: { darkMode: 'class' } };
+</script>
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.sheetjs.com/xlsx-0.20.1/package/dist/xlsx.full.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&family=Noto+Sans+TC:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* ─── Design Tokens ─────────────────────────────────────────── */
+:root {
+  --font-sans: 'Plus Jakarta Sans', 'Noto Sans TC', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, monospace;
 
-            --bg-dark: #111827;
-            --text-dark: #ffffff;
-            --card-bg-dark: #1f2937;
-            --muted-text-dark: #9ca3af;
-            --border-dark: #374151;
-            --input-bg-dark: #374151;
-        }
-        body {
-            font-family: 'Noto Sans TC', sans-serif;
-            transition: background-color 0.3s, color 0.3s;
-        }
-        .theme-light { background-color: var(--bg-light); color: var(--text-light); }
-        .theme-dark  { background-color: var(--bg-dark);  color: var(--text-dark);  }
-        .card { background-color: var(--card-bg-light); border: 1px solid var(--border-light); }
-        .dark .card { background-color: var(--card-bg-dark); border-color: var(--border-dark); }
-        .form-input { background-color: var(--input-bg-light); border: 1px solid var(--border-light); }
-        .dark .form-input { background-color: var(--input-bg-dark); border-color: var(--border-dark); color: var(--text-dark); }
-        .text-muted { color: var(--muted-text-light); }
-        .dark .text-muted { color: var(--muted-text-dark); }
-        .btn-primary { background-color: var(--primary-color); }
-        .btn-primary:hover { background-color: var(--primary-hover); }
-        .btn-danger { background-color: var(--danger-color); }
-        .btn-danger:hover { background-color: var(--danger-hover); }
-        button:disabled { opacity: 0.45; cursor: not-allowed; }
+  /* Light */
+  --bg-page:        #fafaf9;
+  --bg-surface:     #ffffff;
+  --bg-surface-2:   #f5f5f4;
+  --bg-inset:       #fafaf9;
+  --border-subtle:  #e7e5e4;
+  --border-default: #d6d3d1;
+  --border-strong:  #a8a29e;
+  --text-primary:   #0c0a09;
+  --text-secondary: #44403c;
+  --text-muted:     #78716c;
+  --text-faint:     #a8a29e;
+  --accent:         #c2410c;
+  --accent-soft:    #fff7ed;
+  --accent-border:  #fed7aa;
+  --accent-text:    #9a3412;
+  --success:        #15803d;
+  --success-soft:   #f0fdf4;
+  --success-border: #bbf7d0;
+  --warn:           #b45309;
+  --warn-soft:      #fffbeb;
+  --warn-border:    #fde68a;
+  --danger:         #b91c1c;
+  --danger-soft:    #fef2f2;
+  --shadow-card:    0 1px 2px rgba(0,0,0,.04), 0 0 0 1px rgba(0,0,0,.03);
+  --shadow-popover: 0 8px 24px rgba(0,0,0,.08), 0 0 0 1px rgba(0,0,0,.04);
 
-        @media (max-width: 767px) {
-            #edit-personnel-sidebar { display: none !important; }
-            #schedule-output { overflow-x: auto !important; }
-        }
+  /* Schedule cell task hue tokens (subtle in light) */
+  --t0: #eff6ff; --t0-fg: #1d4ed8;
+  --t1: #f0fdf4; --t1-fg: #15803d;
+  --t2: #faf5ff; --t2-fg: #7c3aed;
+  --t3: #fff7ed; --t3-fg: #c2410c;
+  --t4: #fdf2f8; --t4-fg: #be185d;
 
-        @keyframes fadeIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
-        .fade-in { animation: fadeIn 0.5s ease-out forwards; }
+  --density-row: 14px;
+  --density-cell: 10px 12px;
+  --radius-card: 12px;
+  --radius-input: 7px;
+  --radius-pill: 9999px;
+}
 
-        .spinner {
-            border: 4px solid rgba(0, 0, 0, 0.1);
-            width: 24px; height: 24px;
-            border-radius: 50%;
-            border-left-color: #fff;
-            animation: spin 1s ease infinite;
-        }
-        @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
+html.dark {
+  --bg-page:        #0a1224;
+  --bg-surface:     #1c2540;
+  --bg-surface-2:   #2a3556;
+  --bg-inset:       #070d1c;
+  --border-subtle:  #3a4a6f;
+  --border-default: #506285;
+  --border-strong:  #768aae;
+  --text-primary:   #f1f5f9;
+  --text-secondary: #cbd5e1;
+  --text-muted:     #94a3b8;
+  --text-faint:     #6b7a9c;
+  --accent:         #fb923c;
+  --accent-soft:    #2e1c0d;
+  --accent-border:  #9a3412;
+  --accent-text:    #fdba74;
+  --success:        #4ade80;
+  --success-soft:   #0d2a1c;
+  --success-border: #15803d;
+  --warn:           #fbbf24;
+  --warn-soft:      #2a1f08;
+  --warn-border:    #92400e;
+  --danger:         #f87171;
+  --danger-soft:    #2e1418;
+  --shadow-card:    0 1px 2px rgba(0,0,0,.5), 0 0 0 1px rgba(148,163,184,.14);
+  --shadow-popover: 0 12px 32px rgba(2,6,23,.7), 0 0 0 1px rgba(148,163,184,.1);
 
-        /* Accordion */
-        .accordion-content { max-height: 0; overflow: hidden; transition: max-height 0.3s ease-out, padding 0.3s ease-out; padding: 0 1rem; }
-        .accordion-item.active .accordion-content { padding: 1rem 1rem; max-height: 1000px; transition: max-height 0.5s ease-in, padding 0.3s ease-in; }
-        .accordion-arrow { transition: transform 0.3s ease-out; }
-        .accordion-item.active .accordion-arrow { transform: rotate(90deg); }
+  --t0: #1d3464; --t0-fg: #bfdbfe;
+  --t1: #1a3f29; --t1-fg: #bbf7d0;
+  --t2: #38255a; --t2-fg: #ddd6fe;
+  --t3: #3a2410; --t3-fg: #fed7aa;
+  --t4: #401b32; --t4-fg: #fbcfe8;
+}
 
-        /* Schedule Table */
-        .schedule-table { border-collapse: separate; border-spacing: 0; width: max-content; min-width: 100%; border: 1px solid var(--border-light); border-radius: 0.75rem; overflow: hidden; box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px 0 rgba(0,0,0,0.06); }
-        .dark .schedule-table { box-shadow: 0 1px 3px 0 rgba(0,0,0,0.3), 0 1px 2px 0 rgba(0,0,0,0.2); }
-        .schedule-table th, .schedule-table td { padding: 0.75rem 1rem; text-align: center; border-bottom: 1px solid var(--border-light); vertical-align: top; }
-        .dark .schedule-table th, .dark .schedule-table td { border-bottom-color: var(--border-dark); }
-        .schedule-table th { font-weight: 600; }
-        .dark .schedule-table th { border-bottom-color: #4b5563; }
-        .schedule-table tbody tr:last-child td { border-bottom: none; }
-        .holiday-cell { background-color: #e5e7eb; color: #4b5563; font-style: italic; }
-        .dark .holiday-cell { background-color: #4b5563; color: #d1d5db; }
-        .dark .schedule-table tbody td { background-color: var(--card-bg-dark); color: var(--text-dark); }
-        .dark .schedule-table tbody td.holiday-cell { background-color: #4b5563; color: #d1d5db; }
-        .dark .schedule-table tbody td.editable-cell:hover { background-color: #1e3a5f; }
-        .dark #edit-personnel-sidebar { background-color: var(--card-bg-dark) !important; border-color: var(--border-dark) !important; color: var(--text-dark); }
-        .dark #edit-personnel-sidebar input { background-color: var(--bg-dark); border-color: var(--border-dark); color: var(--text-dark); }
-        .dark #edit-personnel-sidebar > div > div { background-color: var(--bg-dark); border-color: var(--border-dark); color: var(--text-dark); }
-        .dark #edit-personnel-sidebar > div > div:hover { background-color: #1e3a5f; border-color: #3b82f6; }
-        .dark .person-tag { background-color: #1e3a5f; color: #93c5fd; }
-        .dark .weekly-stats-card { background-color: var(--card-bg-dark); border-color: var(--border-dark); color: var(--text-dark); }
-        .dark .weekly-stats-card .text-gray-700 { color: #d1d5db; }
+/* ─── Dark-mode overrides ─── */
+html.dark .brand-mark {
+  background: var(--bg-surface-2);
+  color: var(--accent-text);
+  border: 1px solid var(--border-subtle);
+}
+html.dark .section.active .section-num {
+  background: var(--accent);
+  color: #0a1224;
+  border-color: var(--accent);
+}
+html.dark .btn-primary {
+  background: var(--accent);
+  color: #0a1224;
+}
+html.dark .btn-primary:hover { filter: brightness(1.05); background: var(--accent); }
+html.dark .switch::after {
+  background: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0,0,0,.5);
+}
+html.dark .seg button.active {
+  background: var(--bg-page);
+  box-shadow: 0 1px 2px rgba(0,0,0,.4), inset 0 0 0 1px var(--border-subtle);
+}
+html.dark .saved-dot,
+html.dark .modal-foot .left.flash .saved-dot {
+  box-shadow: none;
+}
 
-        /* Edit Toolbar */
-        #edit-toolbar { background-color: #eff6ff; border-color: #bfdbfe; }
-        .dark #edit-toolbar { background-color: #1e3a5f; border-color: #1e40af; }
-        .dark #edit-toolbar .edit-toolbar-label { color: #93c5fd; }
-        .dark #edit-toolbar #edit-status { color: #9ca3af; }
+/* Density variants */
+html[data-density="compact"] { --density-row: 9px; --density-cell: 6px 9px; }
+html[data-density="cozy"]    { --density-row: 18px; --density-cell: 14px 16px; }
 
-        /* Personnel View */
-        .pv-th { background-color: #f3f4f6; border: 1px solid #d1d5db; }
-        .dark .pv-th { background-color: #374151; border-color: #6b7280; color: #f9fafb; }
-        .pv-td { border: 1px solid #d1d5db; }
-        .dark .pv-td { border-color: #6b7280; }
-        .pv-name { background-color: #ffffff; border-right: 2px solid #d1d5db; }
-        .dark .pv-name { background-color: #1f2937; border-right-color: #6b7280; color: #f9fafb; }
-        .pv-holiday { background-color: #f3f4f6; color: #9ca3af; }
-        .dark .pv-holiday { background-color: #374151; color: #6b7280; }
-        #personnel-view tbody tr:nth-child(even) .pv-td:not([class*="pv-task"]):not(.pv-holiday),
-        #personnel-view tbody tr:nth-child(even) .pv-name { background-color: #f9fafb; }
-        .dark #personnel-view tbody tr:nth-child(even) .pv-td:not([class*="pv-task"]):not(.pv-holiday),
-        .dark #personnel-view tbody tr:nth-child(even) .pv-name { background-color: #111827; }
-        .pv-task-0 { background-color: #dbeafe; color: #1e40af; }
-        .dark .pv-task-0 { background-color: #1e3a8a; color: #bfdbfe; }
-        .pv-task-1 { background-color: #dcfce7; color: #166534; }
-        .dark .pv-task-1 { background-color: #14532d; color: #bbf7d0; }
-        .pv-task-2 { background-color: #f3e8ff; color: #6b21a8; }
-        .dark .pv-task-2 { background-color: #581c87; color: #e9d5ff; }
-        .pv-task-3 { background-color: #ffedd5; color: #9a3412; }
-        .dark .pv-task-3 { background-color: #7c2d12; color: #fed7aa; }
-        .pv-task-4 { background-color: #fce7f3; color: #9d174d; }
-        .dark .pv-task-4 { background-color: #831843; color: #fbcfe8; }
-        .pv-task-5 { background-color: #ccfbf1; color: #115e59; }
-        .dark .pv-task-5 { background-color: #134e4a; color: #99f6e4; }
+/* ─── Reset & base ──────────────────────────────────────────── */
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--bg-page);
+  letter-spacing: -0.005em;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv02","cv03","cv04","cv11";
+}
+button { font-family: inherit; font-size: inherit; color: inherit; cursor: pointer; border: 0; background: transparent; padding: 0; }
+input, select { font-family: inherit; font-size: inherit; color: inherit; }
+a { color: inherit; text-decoration: none; }
+.mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 
-        /* Toast */
-        .toast { padding: 12px 18px; border-radius: 8px; color: white; font-size: 14px; max-width: 320px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); opacity: 0; transform: translateX(40px); transition: opacity 0.25s ease, transform 0.25s ease; pointer-events: auto; word-break: break-word; }
-        .toast.show { opacity: 1; transform: translateX(0); }
-        .toast.success { background: #16a34a; }
-        .toast.error   { background: #dc2626; }
-        .toast.warning { background: #d97706; }
-        .toast.info    { background: #2563eb; }
+/* ─── Layout ────────────────────────────────────────────────── */
+.app { max-width: 1400px; margin: 0 auto; padding: 32px 32px 64px; }
 
-        @media print {
-            header { display: none !important; }
-            .lg\:col-span-1 { display: none !important; }
-            #output-container > div:first-child { display: none !important; }
-            .lg\:col-span-2 > div:not(#output-container) { display: none !important; }
-            #output-container { margin: 0 !important; padding: 0 !important; border: none !important; box-shadow: none !important; background: white !important; }
-            #schedule-output { overflow: visible !important; }
-            .schedule-table { page-break-inside: avoid; width: 100% !important; }
-        }
-    </style>
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-bottom: 24px; margin-bottom: 24px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.brand { display: flex; align-items: center; gap: 14px; }
+.brand-mark {
+  width: 36px; height: 36px; border-radius: 8px;
+  background: var(--text-primary); color: var(--bg-surface);
+  display: grid; place-items: center; font-weight: 700; font-size: 16px;
+  letter-spacing: -0.02em;
+}
+.brand-title { font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
+.brand-sub   { font-size: 12px; color: var(--text-muted); margin-top: 1px; }
+.brand-sub .profile-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  background: var(--bg-surface-2); border: 1px solid var(--border-subtle);
+  font-weight: 500; color: var(--text-secondary); font-size: 11px;
+  margin-left: 6px;
+}
+.profile-pill::before { content: ""; width: 5px; height: 5px; border-radius: 50%; background: var(--accent); }
+
+.topbar-actions { display: flex; align-items: center; gap: 8px; }
+.icon-btn {
+  width: 32px; height: 32px; border-radius: 7px;
+  display: grid; place-items: center;
+  color: var(--text-secondary);
+  transition: background .15s, color .15s;
+  position: relative;
+}
+.icon-btn:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+.icon-btn svg { width: 16px; height: 16px; }
+.icon-btn .count-badge {
+  position: absolute; top: -2px; right: -2px;
+  min-width: 14px; height: 14px;
+  padding: 0 3px;
+  border-radius: 7px;
+  background: var(--accent);
+  color: #fff;
+  font: 600 9px var(--font-mono);
+  display: grid; place-items: center;
+  border: 1.5px solid var(--bg-page);
+  letter-spacing: 0;
+}
+.icon-btn.disabled {
+  color: var(--text-faint);
+  cursor: not-allowed;
+  pointer-events: none;
+}
+.icon-btn.disabled .count-badge { display: none; }
+
+.status-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: var(--radius-pill);
+  background: var(--success-soft); border: 1px solid var(--success-border);
+  color: var(--success); font-size: 11px; font-weight: 500;
+  cursor: pointer; transition: filter .15s;
+}
+.status-chip:hover { filter: brightness(0.97); }
+.status-chip .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); }
+.status-chip.connecting {
+  background: var(--bg-surface-2);
+  border-color: var(--border-default);
+  color: var(--text-secondary);
+}
+.status-chip.connecting .dot {
+  background: var(--text-faint);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+.status-chip.offline {
+  background: var(--danger-soft);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.status-chip.offline .dot { background: var(--danger); }
+@keyframes pulse { 0%,100% { opacity: 0.4; } 50% { opacity: 1; } }
+
+.grid {
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  gap: 24px;
+}
+@media (max-width: 1023px) { .grid { grid-template-columns: 1fr; } }
+
+/* ─── Card ──────────────────────────────────────────────────── */
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+}
+
+/* ─── Sidebar Sections ─────────────────────────────────────── */
+.section + .section { margin-top: 12px; }
+.section-header {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%; padding: 14px 16px; text-align: left;
+  border-bottom: 1px solid transparent;
+  transition: border-color .2s;
+}
+.section.active .section-header { border-color: var(--border-subtle); background: var(--bg-surface-2); }
+.section + .section .section-header { border-top: 1px solid var(--border-subtle); }
+.section:first-child .section-header { border-top: none; }
+.section-num {
+  display: inline-grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 5px;
+  background: var(--bg-surface-2); border: 1px solid var(--border-subtle);
+  font: 500 11px var(--font-mono); color: var(--text-muted);
+}
+.section.active .section-num { background: var(--text-primary); color: var(--bg-surface); border-color: var(--text-primary); }
+.section-title { font-size: 13px; font-weight: 600; letter-spacing: -0.005em; }
+.section-chevron { margin-left: auto; color: var(--text-faint); transition: transform .2s; }
+.section.active .section-chevron { transform: rotate(90deg); color: var(--text-secondary); }
+.section-chevron svg { width: 14px; height: 14px; display: block; }
+
+.section-body {
+  max-height: 0; overflow: hidden;
+  transition: max-height .25s ease, padding .25s ease;
+  padding: 0 16px;
+}
+.section.active .section-body { max-height: 1400px; padding: 4px 16px 16px; }
+
+/* ─── Accordion compatibility ─────────────────────────────── */
+.accordion-item { }
+.accordion-item.active .section-body { max-height: 1400px; padding: 4px 16px 16px; }
+.accordion-item.active .section-header { border-color: var(--border-subtle); background: var(--bg-surface-2); }
+.accordion-item.active .section-num { background: var(--text-primary); color: var(--bg-surface); border-color: var(--text-primary); }
+.accordion-item.active .section-chevron { transform: rotate(90deg); color: var(--text-secondary); }
+
+/* ─── Form controls ─────────────────────────────────────────── */
+.field { display: flex; flex-direction: column; gap: 6px; }
+.field-label { font-size: 11px; font-weight: 500; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.04em; }
+.input, .select {
+  width: 100%; padding: 7px 10px;
+  background: var(--bg-inset); color: var(--text-primary);
+  border: 1px solid var(--border-default); border-radius: var(--radius-input);
+  font-size: 13px; outline: none;
+  transition: border-color .15s, box-shadow .15s;
+}
+.input:focus, .select:focus {
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 3px var(--bg-surface-2);
+}
+.input.num { font-family: var(--font-mono); text-align: center; }
+
+/* ─── Buttons (unified) ─────────────────────────────────────── */
+.btn { display: inline-flex; align-items: center; justify-content: center; gap: 6px;
+  padding: 7px 12px; border-radius: var(--radius-input);
+  font-size: 13px; font-weight: 500; line-height: 1;
+  transition: background .15s, color .15s, border-color .15s, transform .05s;
+  border: 1px solid transparent; white-space: nowrap;
+}
+.btn:active { transform: translateY(0.5px); }
+.btn-primary { background: var(--text-primary); color: var(--bg-surface); }
+.btn-primary:hover { background: var(--text-secondary); }
+.btn-accent { background: var(--accent); color: #fff; }
+.btn-accent:hover { filter: brightness(1.05); }
+.btn-secondary { background: var(--bg-surface-2); color: var(--text-primary); border-color: var(--border-default); }
+.btn-secondary:hover { background: var(--border-default); border-color: var(--border-strong); }
+.btn-ghost { color: var(--text-secondary); }
+.btn-ghost:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+.btn-danger-ghost { color: var(--danger); }
+.btn-danger-ghost:hover { background: var(--danger-soft); }
+.btn-danger { background: var(--danger); color: #fff; }
+.btn-danger:hover { background: var(--danger); filter: brightness(1.05); }
+html.dark .btn-danger { color: #fff; }
+.btn-sm { padding: 5px 9px; font-size: 12px; }
+.btn-lg { padding: 11px 16px; font-size: 14px; }
+.btn-iconOnly { padding: 6px; }
+.btn-iconOnly svg { width: 14px; height: 14px; }
+.btn svg { width: 14px; height: 14px; }
+button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* ─── Profile dropdown row ─────────────────────────────────── */
+.profile-row { display: flex; align-items: center; gap: 8px; margin-bottom: 12px; }
+.profile-row .select { flex: 1; }
+.profile-actions { display: grid; grid-template-columns: repeat(5, 1fr); gap: 6px; }
+.profile-actions .btn { padding: 6px 0; font-size: 12px; }
+
+/* ─── Task/Personnel list ──────────────────────────────────── */
+.list-row {
+  display: grid; align-items: center; gap: 6px;
+  padding: 6px 0;
+}
+.list-row.task { grid-template-columns: 1fr 52px 44px 22px; }
+.list-row.personnel { grid-template-columns: 1fr 56px 28px 28px 22px; }
+.list-row .input { padding: 5px 8px; font-size: 13px; }
+.list-row .micro-btn {
+  width: 26px; height: 26px; border-radius: 5px;
+  display: grid; place-items: center; color: var(--text-faint);
+  transition: background .15s, color .15s;
+}
+.list-row .micro-btn:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+.list-row .micro-btn.danger:hover { background: var(--danger-soft); color: var(--danger); }
+.list-row .micro-btn svg { width: 14px; height: 14px; }
+
+.list-headers {
+  display: grid; gap: 6px;
+  padding: 0 0 6px;
+  font: 500 10px var(--font-sans);
+  color: var(--text-faint);
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.list-headers.task { grid-template-columns: 1fr 52px 44px 22px; }
+.list-headers.personnel { grid-template-columns: 1fr 56px 28px 28px 22px; }
+.list-headers > span { text-align: center; }
+.list-headers > span:first-child { text-align: left; }
+
+.list-divider { height: 1px; background: var(--border-subtle); margin: 6px 0; }
+
+/* ─── Capacity panel ─────────────────────────────────────────── */
+.capacity {
+  margin-top: 12px;
+  padding: 10px 12px; border-radius: 8px;
+  background: var(--bg-inset); border: 1px solid var(--border-subtle);
+}
+.capacity-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.capacity-label { font-size: 11px; color: var(--text-muted); font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+.capacity-numbers { font: 500 13px var(--font-mono); color: var(--text-primary); }
+.capacity-numbers .demand { color: var(--text-muted); }
+.capacity-bar { height: 6px; background: var(--bg-surface-2); border-radius: 3px; overflow: hidden; position: relative; }
+.capacity-fill { height: 100%; background: var(--success); transition: width .3s; }
+.capacity.short .capacity-fill { background: var(--danger); }
+.capacity-note { margin-top: 8px; font-size: 11px; color: var(--text-muted); }
+.capacity.short .capacity-note { color: var(--danger); }
+
+/* ─── Add row ───────────────────────────────────────────────── */
+.add-row { display: flex; gap: 6px; margin-top: 12px; }
+.add-row .input { padding: 7px 10px; }
+.add-row .btn { flex-shrink: 0; }
+
+/* ─── Generate panel ────────────────────────────────────────── */
+.generate-fields { display: flex; flex-direction: column; gap: 12px; }
+.generate-fields .input { padding: 8px 10px; }
+.holiday-trigger {
+  width: 100%; padding: 8px 10px;
+  background: var(--bg-inset); color: var(--text-primary);
+  border: 1px solid var(--border-default); border-radius: var(--radius-input);
+  font-size: 13px;
+  display: flex; align-items: center; justify-content: space-between;
+}
+.holiday-trigger:hover { background: var(--bg-surface-2); }
+.holiday-trigger .count { color: var(--text-muted); font-size: 11px; }
+
+.generate-cta {
+  width: 100%; margin-top: 16px;
+  padding: 11px 0; border-radius: var(--radius-input);
+  background: var(--accent); color: white; font-weight: 600; font-size: 14px;
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  transition: filter .15s;
+}
+.generate-cta:hover { filter: brightness(1.05); }
+.generate-cta .kbd {
+  font: 500 10px var(--font-mono);
+  padding: 2px 5px; border-radius: 3px;
+  background: rgba(255,255,255,.18); color: rgba(255,255,255,.85);
+  margin-left: 4px;
+}
+.cta-spinner {
+  width: 14px; height: 14px;
+  border: 2px solid rgba(255,255,255,.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: ctaSpin .8s linear infinite;
+}
+@keyframes ctaSpin { to { transform: rotate(360deg); } }
+.generate-cta.loading { pointer-events: none; opacity: 0.85; }
+
+/* ─── Right panel ───────────────────────────────────────────── */
+.panel-head {
+  display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between;
+  gap: 12px; padding: 16px 20px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.panel-title-row { display: flex; align-items: center; gap: 12px; }
+.panel-title { font-size: 16px; font-weight: 600; letter-spacing: -0.01em; }
+.panel-meta { font-size: 12px; color: var(--text-muted); font-family: var(--font-mono); }
+
+.seg {
+  display: inline-flex; padding: 3px; background: var(--bg-surface-2);
+  border-radius: 7px; border: 1px solid var(--border-subtle);
+}
+.seg button {
+  padding: 4px 10px; border-radius: 5px; font-size: 12px; font-weight: 500;
+  color: var(--text-muted); transition: color .15s, background .15s;
+}
+.seg button.active { background: var(--bg-surface); color: var(--text-primary); box-shadow: 0 1px 2px rgba(0,0,0,.05); }
+.seg button:hover:not(.active) { color: var(--text-primary); }
+
+.panel-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+
+/* ─── Edit toolbar ──────────────────────────────────────────── */
+.edit-toolbar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 20px;
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--accent-border);
+  color: var(--accent-text);
+  font-size: 12px;
+}
+.edit-toolbar .label { font-weight: 600; display: flex; align-items: center; gap: 6px; }
+.edit-toolbar .label::before {
+  content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent);
+}
+.edit-toolbar .meta { color: var(--text-muted); }
+.edit-toolbar .spacer { flex: 1; }
+
+/* ─── Schedule table ────────────────────────────────────────── */
+.schedule-area { padding: 20px; }
+
+/* ─── Edit mode: personnel drag sidebar ─────────────────── */
+.schedule-region {
+  display: grid;
+  grid-template-columns: 1fr;
+  transition: grid-template-columns .25s ease;
+}
+body.editing .schedule-region {
+  grid-template-columns: 1fr 220px;
+}
+.edit-pers-sidebar {
+  display: none;
+  align-self: start;
+  position: sticky; top: 16px;
+  margin: 20px 20px 20px 0;
+  padding: 14px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  max-height: calc(100vh - 32px);
+  overflow: hidden;
+}
+body.editing .edit-pers-sidebar { display: flex; flex-direction: column; }
+.edit-pers-sidebar header {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 10px;
+  flex-shrink: 0;
+}
+.edit-pers-sidebar h3 {
+  margin: 0; font-size: 12px; font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.005em;
+}
+.edit-pers-sidebar .hint {
+  font: 500 10px var(--font-mono);
+  color: var(--text-faint);
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.drag-list {
+  display: flex; flex-direction: column; gap: 6px;
+  overflow-y: auto;
+  flex: 1; min-height: 0;
+  padding-right: 4px;
+}
+.drag-card {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  font-size: 13px; font-weight: 500;
+  color: var(--text-primary);
+  cursor: grab;
+  user-select: none;
+  transition: background .12s, border-color .12s, transform .08s;
+}
+.drag-card:hover { background: var(--bg-surface-2); border-color: var(--border-default); }
+.drag-card:active { cursor: grabbing; transform: scale(0.98); }
+.drag-card.dragging { opacity: 0.4; }
+.drag-card .grip {
+  color: var(--text-faint);
+  display: grid; place-items: center;
+  flex-shrink: 0;
+}
+.drag-card .grip svg { width: 12px; height: 12px; }
+.drag-card .meta {
+  margin-left: auto;
+  font: 500 10px var(--font-mono);
+  color: var(--text-muted);
+}
+
+/* Drop targets in edit mode */
+body.editing .s-table .editable-cell { transition: background .15s, outline .12s; }
+body.editing .s-table .editable-cell.drop-hover {
+  background: var(--accent-soft);
+  outline: 2px dashed var(--accent);
+  outline-offset: -2px;
+}
+body.editing .person-tag { cursor: grab; }
+body.editing .person-tag:active { cursor: grabbing; }
+
+/* Edit toolbar shown only when in edit mode */
+body:not(.editing) .edit-toolbar { display: none; }
+
+.week-block + .week-block { margin-top: 28px; }
+.week-head { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 10px; }
+.week-label { display: flex; align-items: baseline; gap: 10px; }
+.week-num {
+  font: 600 11px var(--font-mono);
+  color: var(--text-muted);
+  background: var(--bg-surface-2);
+  padding: 2px 8px; border-radius: 4px;
+  border: 1px solid var(--border-subtle);
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.week-date { font-size: 13px; color: var(--text-secondary); font-family: var(--font-mono); }
+.week-stats { font-size: 11px; color: var(--text-muted); font-family: var(--font-mono); }
+.week-stats .ok { color: var(--success); }
+.week-stats .warn { color: var(--warn); }
+
+.s-table {
+  width: 100%; border-collapse: separate; border-spacing: 0;
+  border: 1px solid var(--border-subtle); border-radius: 10px; overflow: hidden;
+  font-size: 13px;
+  background: var(--bg-surface);
+}
+.s-table th, .s-table td {
+  padding: var(--density-cell);
+  text-align: center;
+  border-bottom: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-subtle);
+  vertical-align: top;
+}
+.s-table th:last-child, .s-table td:last-child { border-right: none; }
+.s-table tr:last-child td { border-bottom: none; }
+.s-table thead th {
+  background: var(--bg-surface-2);
+  font-size: 11px; font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.06em;
+  padding: 10px 12px;
+}
+.s-table thead th .dow { color: var(--text-primary); font-size: 12px; letter-spacing: 0; text-transform: none; }
+.s-table thead th .date { display: block; margin-top: 2px; font-family: var(--font-mono); font-weight: 400; color: var(--text-muted); }
+.s-table .task-cell {
+  text-align: left;
+  background: var(--bg-inset);
+  font-weight: 600;
+  font-size: 13px;
+  padding-left: 16px;
+  border-right: 1px solid var(--border-subtle);
+}
+.s-table .task-cell .task-meta {
+  display: block;
+  font: 400 10px var(--font-mono);
+  color: var(--text-faint);
+  margin-top: 2px;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.s-table .task-cell .priority-dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  margin-right: 6px; vertical-align: middle;
+  background: var(--accent);
+}
+.s-table .task-cell .priority-dot.p2 { background: var(--text-secondary); }
+.s-table .task-cell .priority-dot.p3 { background: var(--text-muted); }
+.s-table .task-cell .priority-dot.p5 { background: var(--text-faint); }
+.s-table .task-cell .priority-dot.p9 { background: var(--text-faint); opacity: 0.5; }
+
+.s-table .editable-cell { cursor: pointer; transition: background .15s; position: relative; }
+.s-table .editable-cell:hover { background: var(--bg-surface-2); }
+.s-table .editable-cell.warn-cell { background: var(--warn-soft); }
+.s-table .editable-cell.warn-cell::after {
+  content: ""; position: absolute; top: 4px; right: 4px;
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--warn);
+}
+.s-table .holiday-cell {
+  background: var(--bg-inset);
+  color: var(--text-faint);
+  font-style: italic;
+  font-size: 12px;
+}
+.s-table .holiday-cell .holiday-label {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  border: 1px dashed var(--border-default);
+  color: var(--text-muted);
+  font-style: normal;
+  font-size: 11px;
+}
+
+/* Person tags inside cells */
+.s-table .editable-cell .persons {
+  display: flex; flex-wrap: wrap; gap: 4px; justify-content: center;
+}
+.person-tag {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  background: var(--bg-surface-2);
+  border: 1px solid var(--border-subtle);
+  font-size: 12px; font-weight: 500; color: var(--text-primary);
+  cursor: grab;
+  user-select: none;
+}
+.person-tag:hover { border-color: var(--border-strong); }
+.person-tag.unfilled {
+  background: transparent;
+  border: 1px dashed var(--border-default);
+  color: var(--text-faint);
+  font-style: italic;
+  cursor: pointer;
+}
+
+/* ─── Fill rate ──────────────────────────────────────────────── */
+.fillrate { margin-top: 24px; padding: 16px 20px; border-top: 1px solid var(--border-subtle); }
+.fillrate-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; }
+.fillrate-title { font-size: 13px; font-weight: 600; }
+.fillrate-grid {
+  display: grid; gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+.fillrate-card {
+  padding: 10px 12px; border-radius: 8px;
+  background: var(--bg-inset); border: 1px solid var(--border-subtle);
+}
+.fillrate-card .name { font-size: 12px; font-weight: 600; }
+.fillrate-card .pri  { font: 500 10px var(--font-mono); color: var(--text-muted); margin-left: 6px; }
+.fillrate-card .nums { font: 500 12px var(--font-mono); color: var(--text-secondary); margin-top: 4px; }
+.fillrate-card .bar { height: 4px; background: var(--bg-surface-2); border-radius: 2px; margin-top: 6px; overflow: hidden; }
+.fillrate-card .bar > div { height: 100%; background: var(--success); }
+.fillrate-card.warn .bar > div { background: var(--warn); }
+.fillrate-card.warn .nums { color: var(--warn); }
+
+/* ─── Saved schedules ───────────────────────────────────────── */
+.saved {
+  margin-top: 16px;
+}
+.saved-head { padding: 14px 20px; border-bottom: 1px solid var(--border-subtle); display: flex; justify-content: space-between; align-items: center; }
+.saved-head .panel-title { font-size: 14px; }
+.saved-list { padding: 6px; }
+.saved-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 7px;
+  transition: background .15s;
+}
+.saved-item:hover { background: var(--bg-surface-2); }
+.saved-item .icon { color: var(--text-faint); display: grid; place-items: center; }
+.saved-item .icon svg { width: 14px; height: 14px; }
+.saved-item .name { flex: 1; font-size: 13px; font-weight: 500; }
+.saved-item .meta { font: 400 11px var(--font-mono); color: var(--text-muted); }
+.saved-item .del { opacity: 0; transition: opacity .15s; }
+.saved-item:hover .del { opacity: 1; }
+
+/* ─── Personnel view table ──────────────────────────────────── */
+.pv-wrap { overflow-x: auto; padding: 20px; }
+.pv-table { border-collapse: separate; border-spacing: 0; font-size: 12px; }
+.pv-table th, .pv-table td {
+  padding: 6px 10px; text-align: center;
+  border-bottom: 1px solid var(--border-subtle);
+  border-right: 1px solid var(--border-subtle);
+  min-width: 64px;
+}
+.pv-table th {
+  background: var(--bg-surface-2);
+  font-weight: 600; font-size: 10px; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.05em;
+}
+.pv-table th .date { display: block; font: 400 10px var(--font-mono); color: var(--text-muted); margin-top: 1px; text-transform: none; letter-spacing: 0; }
+.pv-table td.name {
+  position: sticky; left: 0; z-index: 1;
+  background: var(--bg-surface);
+  font-weight: 600; text-align: left;
+  border-right: 1px solid var(--border-default);
+  min-width: 120px;
+  padding: 8px 12px;
+}
+.pv-table td.name .nm-row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 8px;
+}
+.pv-table td.name .nm-name { font-size: 13px; }
+.pv-table td.name .nm-total {
+  font: 600 12px var(--font-mono);
+  color: var(--text-secondary);
+}
+.pv-table td.name .nm-total .max {
+  color: var(--text-faint); font-weight: 400; font-size: 10px;
+}
+.pv-table td.name .nm-delta {
+  font: 500 10px var(--font-mono);
+  color: var(--text-faint);
+  margin-left: 4px;
+}
+.pv-table td.name.over .nm-total { color: var(--warn); }
+.pv-table td.name.over .nm-delta { color: var(--warn); }
+.pv-table td.name .nm-bar {
+  height: 3px; background: var(--bg-inset);
+  border-radius: 2px; overflow: hidden;
+  margin-top: 5px;
+}
+.pv-table td.name .nm-bar > div {
+  height: 100%; background: var(--text-faint);
+  transition: width .3s;
+}
+.pv-table td.name.over .nm-bar > div { background: var(--warn); }
+.pv-table .holiday-pv { background: var(--bg-inset); color: var(--text-faint); }
+.pv-table .t-0 { background: var(--t0); color: var(--t0-fg); font-weight: 500; }
+.pv-table .t-1 { background: var(--t1); color: var(--t1-fg); font-weight: 500; }
+.pv-table .t-2 { background: var(--t2); color: var(--t2-fg); font-weight: 500; }
+.pv-table .t-3 { background: var(--t3); color: var(--t3-fg); font-weight: 500; }
+.pv-table .t-4 { background: var(--t4); color: var(--t4-fg); font-weight: 500; }
+
+.pv-legend {
+  display: flex; flex-wrap: wrap; gap: 10px;
+  padding: 0 20px 16px; font-size: 11px; color: var(--text-muted);
+}
+.pv-legend .chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 9px; border-radius: var(--radius-pill);
+  font-weight: 500; font-size: 11px;
+}
+
+.pv-summary {
+  display: flex; gap: 20px; padding: 0 20px 12px;
+  font-size: 12px; color: var(--text-muted);
+}
+.pv-summary span strong {
+  color: var(--text-primary); font-family: var(--font-mono); font-weight: 600;
+  margin-left: 6px;
+}
+.pv-summary .pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: var(--radius-pill);
+  background: var(--bg-inset); border: 1px solid var(--border-subtle);
+}
+
+/* ─── Footer ────────────────────────────────────────────────── */
+.app-footer {
+  margin-top: 40px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border-subtle);
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11px; color: var(--text-faint);
+}
+.app-footer .kbd { font: 500 10px var(--font-mono); padding: 1px 5px; border: 1px solid var(--border-subtle); border-radius: 3px; background: var(--bg-surface); }
+
+/* ─── Conflict visuals ──────────────────────────────── */
+.s-table .editable-cell.has-conflict {
+  background: var(--danger-soft);
+  position: relative;
+}
+.s-table .editable-cell.has-conflict::before {
+  content: ""; position: absolute; inset: 0;
+  border: 1px solid var(--danger);
+  border-radius: 0; pointer-events: none;
+  opacity: 0.4;
+}
+.s-table .editable-cell.has-conflict .person-tag {
+  background: var(--bg-surface);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.s-table .editable-cell .conflict-badge {
+  position: absolute; top: 2px; right: 2px;
+  width: 14px; height: 14px;
+  background: var(--danger); color: #fff;
+  border-radius: 50%;
+  font: 700 9px var(--font-mono);
+  display: grid; place-items: center;
+  z-index: 2;
+  cursor: help;
+}
+
+.conflict-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 9px; margin-left: 8px;
+  background: var(--danger-soft);
+  border: 1px solid var(--danger);
+  border-radius: var(--radius-pill);
+  font: 500 11px var(--font-sans); color: var(--danger);
+  cursor: pointer;
+  transition: filter .15s;
+}
+.conflict-chip:hover { filter: brightness(1.05); }
+.conflict-chip .dot {
+  width: 5px; height: 5px; border-radius: 50%; background: var(--danger);
+}
+
+/* ─── Toast ─────────────────────────────────────────────── */
+.toast-container {
+  position: fixed; bottom: 64px; right: 20px;
+  display: flex; flex-direction: column; gap: 8px;
+  z-index: 200; pointer-events: none;
+  max-width: 360px;
+}
+.toast {
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 10px 14px 10px 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9px;
+  box-shadow: var(--shadow-popover);
+  font-size: 13px; color: var(--text-primary);
+  pointer-events: auto;
+  opacity: 0; transform: translateX(40px);
+  transition: opacity .22s, transform .25s cubic-bezier(.22,.61,.36,1);
+  min-width: 240px;
+}
+.toast.show { opacity: 1; transform: translateX(0); }
+.toast .ticon {
+  width: 18px; height: 18px; border-radius: 5px;
+  display: grid; place-items: center;
+  flex-shrink: 0; margin-top: 1px;
+  color: #fff;
+}
+.toast .ticon svg { width: 11px; height: 11px; }
+.toast .tbody { flex: 1; line-height: 1.45; }
+.toast .ttitle { font-weight: 600; font-size: 13px; }
+.toast .tdesc { font-size: 11.5px; color: var(--text-muted); margin-top: 2px; }
+.toast .tclose {
+  width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0;
+  display: grid; place-items: center;
+  color: var(--text-faint);
+}
+.toast .tclose:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+.toast .tclose svg { width: 11px; height: 11px; }
+.toast.success .ticon { background: var(--success); }
+.toast.error   .ticon { background: var(--danger); }
+.toast.warning .ticon { background: var(--warn); }
+.toast.info    .ticon { background: var(--text-secondary); }
+.toast.success { border-left: 3px solid var(--success); }
+.toast.error   { border-left: 3px solid var(--danger); }
+.toast.warning { border-left: 3px solid var(--warn); }
+.toast.info    { border-left: 3px solid var(--text-secondary); }
+
+/* ─── Popover menu ────────────────────────────────────── */
+.popover-menu {
+  position: absolute;
+  z-index: 150;
+  min-width: 180px;
+  padding: 4px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  box-shadow: var(--shadow-popover);
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity .12s, transform .15s cubic-bezier(.22,.61,.36,1);
+}
+.popover-menu.open { opacity: 1; transform: translateY(0); }
+.popover-item {
+  display: flex; align-items: center; gap: 10px;
+  width: 100%; padding: 7px 10px;
+  border-radius: 5px;
+  font-size: 13px; color: var(--text-primary);
+  text-align: left;
+  transition: background .12s, color .12s;
+}
+.popover-item:hover { background: var(--bg-surface-2); }
+.popover-item svg { width: 14px; height: 14px; color: var(--text-muted); flex-shrink: 0; }
+.popover-item:hover svg { color: var(--text-primary); }
+.popover-item.danger { color: var(--danger); }
+.popover-item.danger svg { color: var(--danger); }
+.popover-item.danger:hover { background: var(--danger-soft); }
+
+/* ─── Modal (shared) ────────────────────────────────────── */
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(15, 23, 42, 0.4);
+  z-index: 110;
+  display: none;
+  align-items: center; justify-content: center;
+  padding: 24px;
+  opacity: 0;
+  transition: opacity .18s;
+}
+html.dark .modal-backdrop { background: rgba(0,0,0,.65); }
+.modal-backdrop.open { display: flex; opacity: 1; }
+
+.modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  box-shadow: var(--shadow-popover);
+  width: 100%;
+  max-width: 480px;
+  max-height: calc(100vh - 48px);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  transform: translateY(8px);
+  opacity: 0;
+  transition: transform .2s cubic-bezier(.22,.61,.36,1), opacity .18s;
+}
+.modal-backdrop.open .modal { transform: translateY(0); opacity: 1; }
+.modal.wide { max-width: 640px; }
+
+.modal-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.modal-head .title { font-size: 15px; font-weight: 600; letter-spacing: -0.005em; }
+.modal-head .sub { font: 500 11px var(--font-mono); color: var(--text-muted); margin-top: 3px; }
+.modal-close {
+  width: 28px; height: 28px; border-radius: 6px;
+  display: grid; place-items: center;
+  color: var(--text-muted);
+}
+.modal-close:hover { background: var(--bg-surface-2); color: var(--text-primary); }
+.modal-close svg { width: 14px; height: 14px; }
+
+.modal-body { flex: 1; overflow-y: auto; padding: 18px 20px; }
+.modal-foot {
+  display: flex; align-items: center; gap: 8px; justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-inset);
+}
+.modal-foot .left { margin-right: auto; font-size: 11px; color: var(--text-muted); }
+.modal-foot .left .saved-dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--success); margin-right: 6px;
+  vertical-align: middle;
+  transition: transform .2s, box-shadow .2s;
+}
+.modal-foot .left.flash {
+  animation: savedFlash .6s ease-out;
+}
+@keyframes savedFlash {
+  0%   { color: var(--success); }
+  60%  { color: var(--success); }
+  100% { color: var(--text-muted); }
+}
+.modal-foot .left.flash .saved-dot {
+  animation: savedDotFlash .6s ease-out;
+}
+@keyframes savedDotFlash {
+  0%   { transform: scale(1.6); box-shadow: 0 0 0 3px var(--success-soft); }
+  100% { transform: scale(1); box-shadow: 0 0 0 0 transparent; }
+}
+
+.modal-section + .modal-section { margin-top: 18px; }
+.modal-section-label {
+  font: 500 10px var(--font-sans);
+  color: var(--text-faint);
+  text-transform: uppercase; letter-spacing: 0.08em;
+  margin-bottom: 10px;
+}
+
+/* Day-of-week toggles for personnel modal */
+.dow-row { display: flex; gap: 6px; }
+.dow-btn {
+  flex: 1;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  padding: 10px 0; border-radius: 8px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  color: var(--text-secondary);
+  font-size: 13px; font-weight: 500;
+  transition: background .15s, border-color .15s, color .15s;
+}
+.dow-btn:hover { background: var(--bg-surface-2); border-color: var(--border-default); }
+.dow-btn.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-text);
+}
+.dow-btn .dow-sub { font: 500 10px var(--font-mono); color: var(--text-faint); margin-top: 2px; }
+.dow-btn.on .dow-sub { color: var(--accent); opacity: .8; }
+
+/* Holiday modal list */
+.holiday-list { display: flex; flex-direction: column; gap: 2px; }
+.holiday-item {
+  display: grid; grid-template-columns: 86px 1fr 44px; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition: background .12s, border-color .12s;
+  cursor: pointer;
+}
+.holiday-item:hover { background: var(--bg-surface-2); }
+.holiday-item.on { background: var(--accent-soft); border-color: var(--accent-border); }
+.holiday-item .date {
+  font: 500 12px var(--font-mono);
+  color: var(--text-muted);
+}
+.holiday-item .name { font-size: 13px; font-weight: 500; }
+.holiday-item .meta { font: 400 11px var(--font-sans); color: var(--text-faint); margin-top: 1px; }
+.switch {
+  position: relative;
+  width: 34px; height: 20px;
+  background: var(--border-default);
+  border-radius: 9999px;
+  transition: background .15s;
+  justify-self: end;
+  flex-shrink: 0;
+}
+.switch::after {
+  content: "";
+  position: absolute; top: 2px; left: 2px;
+  width: 16px; height: 16px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform .18s cubic-bezier(.22,.61,.36,1);
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+}
+.holiday-item.on .switch { background: var(--accent); }
+.holiday-item.on .switch::after { transform: translateX(14px); }
+
+/* Diff modal */
+.diff-summary {
+  display: flex; gap: 14px;
+  padding: 10px 12px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  margin-bottom: 14px;
+  font-size: 12px;
+}
+.diff-summary .pill {
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.diff-summary .pill .dot { width: 6px; height: 6px; border-radius: 50%; }
+.diff-summary .pill.add .dot { background: var(--success); }
+.diff-summary .pill.rem .dot { background: var(--danger); }
+.diff-summary .pill strong { font-family: var(--font-mono); font-weight: 600; color: var(--text-primary); margin-left: 2px; }
+.diff-empty {
+  text-align: center; padding: 36px 16px;
+  color: var(--text-muted); font-size: 13px;
+}
+.diff-empty .icn {
+  width: 40px; height: 40px; border-radius: 50%;
+  margin: 0 auto 10px;
+  display: grid; place-items: center;
+  background: var(--success-soft); color: var(--success);
+  border: 1px solid var(--success-border);
+}
+.diff-list { display: flex; flex-direction: column; gap: 10px; }
+.diff-group {
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.diff-group-head {
+  padding: 8px 12px;
+  background: var(--bg-inset);
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+  display: flex; align-items: center; gap: 8px;
+}
+.diff-group-head .week-pill {
+  font: 500 10px var(--font-mono);
+  color: var(--text-muted);
+  background: var(--bg-surface);
+  padding: 1px 6px; border-radius: 3px;
+  border: 1px solid var(--border-subtle);
+  letter-spacing: 0.04em;
+}
+.diff-group-head .label { font-weight: 500; color: var(--text-primary); }
+.diff-changes { padding: 8px 12px; display: flex; flex-direction: column; gap: 4px; }
+.diff-line {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13px;
+}
+.diff-line .marker {
+  width: 16px; height: 16px; border-radius: 4px;
+  display: grid; place-items: center;
+  font: 700 11px var(--font-mono);
+}
+.diff-line.add .marker { background: var(--success-soft); color: var(--success); border: 1px solid var(--success-border); }
+.diff-line.rem .marker { background: var(--danger-soft); color: var(--danger); border: 1px solid var(--danger); }
+.diff-line .person { font-weight: 500; }
+.diff-line.add .person { color: var(--success); }
+.diff-line.rem .person { color: var(--danger); text-decoration: line-through; text-decoration-thickness: 1px; }
+
+/* ─── Misc ────────────────────────────────────────────────── */
+@keyframes fadeIn { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
+.fade-in { animation: fadeIn 0.5s ease-out forwards; }
+
+/* hidden utility for initial state */
+.hidden { display: none !important; }
+
+@media (max-width: 767px) {
+  #edit-personnel-sidebar { display: none !important; }
+  #schedule-output { overflow-x: auto !important; }
+}
+
+@media print {
+  .topbar { display: none !important; }
+  aside { display: none !important; }
+  .panel-head > .panel-actions { display: none !important; }
+  #output-container { margin: 0 !important; padding: 0 !important; border: none !important; box-shadow: none !important; background: white !important; }
+  #schedule-output { overflow: visible !important; }
+  .s-table { page-break-inside: avoid; width: 100% !important; }
+}
+
+/* ─── Compatibility shims ─────────────────────────────────── */
+/* form-input: used by dynamically injected task/personnel rows in main.js */
+.form-input {
+  background: var(--bg-inset);
+  color: var(--text-primary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-input);
+  font-size: 13px;
+  outline: none;
+  transition: border-color .15s;
+}
+.form-input:focus {
+  border-color: var(--text-primary);
+  box-shadow: 0 0 0 3px var(--bg-surface-2);
+}
+/* text-muted: used in placeholder paragraphs */
+.text-muted { color: var(--text-muted); }
+
+/* Compatibility: old schedule-table class (used by scheduleRenderer.js) */
+.schedule-table { border-collapse: separate; border-spacing: 0; width: max-content; min-width: 100%; border: 1px solid var(--border-subtle); border-radius: 0.75rem; overflow: hidden; }
+.schedule-table th, .schedule-table td { padding: 0.75rem 1rem; text-align: center; border-bottom: 1px solid var(--border-subtle); vertical-align: top; }
+.schedule-table th { font-weight: 600; }
+.schedule-table tbody tr:last-child td { border-bottom: none; }
+.holiday-cell { background-color: var(--bg-inset); color: var(--text-faint); font-style: italic; }
+.editable-cell { cursor: pointer; transition: background .15s; }
+.editable-cell:hover { background: var(--bg-surface-2); }
+
+/* Personnel view compatibility classes */
+.pv-th { background-color: var(--bg-surface-2); border: 1px solid var(--border-default); }
+.pv-td { border: 1px solid var(--border-subtle); }
+.pv-name { background-color: var(--bg-surface); border-right: 2px solid var(--border-default); }
+.pv-holiday { background-color: var(--bg-inset); color: var(--text-faint); }
+.pv-task-0 { background-color: var(--t0); color: var(--t0-fg); }
+.pv-task-1 { background-color: var(--t1); color: var(--t1-fg); }
+.pv-task-2 { background-color: var(--t2); color: var(--t2-fg); }
+.pv-task-3 { background-color: var(--t3); color: var(--t3-fg); }
+.pv-task-4 { background-color: var(--t4); color: var(--t4-fg); }
+.pv-task-5 { background-color: #ccfbf1; color: #115e59; }
+</style>
 </head>
 <body class="theme-light">
 
-    <div class="container mx-auto p-4 md:p-8">
+<div class="app">
 
-        <header class="flex justify-between items-center mb-8">
-            <div>
-                <h1 class="text-3xl md:text-4xl font-bold text-blue-600 dark:text-blue-400">智慧排班系統</h1>
-                <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">設定檔：<span id="active-profile-badge" class="font-medium text-blue-500 dark:text-blue-300"></span></p>
+  <div class="topbar">
+    <div class="brand">
+      <div class="brand-mark">排</div>
+      <div>
+        <div class="brand-title">智慧排班系統</div>
+        <div class="brand-sub">
+          v2
+          <span class="profile-pill" id="active-profile-badge"></span>
+        </div>
+      </div>
+    </div>
+    <div class="topbar-actions">
+      <div id="status-container" class="status-chip" title="正在檢查連線狀態...">
+        <span class="dot" id="status-indicator"></span>
+        <span id="status-text">正在檢查連線...</span>
+      </div>
+      <button class="icon-btn" id="undo" title="復原 (⌘Z)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 14L4 9l5-5"/><path d="M4 9h11a5 5 0 010 10h-4"/></svg>
+        <span class="count-badge" id="undo-badge" style="display:none">0</span>
+      </button>
+      <button class="icon-btn" id="redo" title="重做 (⌘⇧Z)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 14l5-5-5-5"/><path d="M20 9H9a5 5 0 000 10h4"/></svg>
+        <span class="count-badge" id="redo-badge" style="display:none">0</span>
+      </button>
+      <button class="icon-btn" id="theme-toggle" title="深色模式">
+        <svg id="theme-icon-light" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+        <svg id="theme-icon-dark" class="hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <div class="grid">
+
+    <!-- ── Left sidebar ── -->
+    <aside>
+      <div class="card" id="accordion-container">
+
+        <!-- Profile management -->
+        <div class="section accordion-item">
+          <button class="section-header accordion-header" data-section="0">
+            <span class="section-num">P</span>
+            <span class="section-title">設定檔管理</span>
+            <span class="section-chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+          </button>
+          <div class="section-body">
+            <div class="profile-row">
+              <select class="select" id="profile-select"></select>
             </div>
-            <button id="theme-toggle" class="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition">
-                <svg id="theme-icon-light" class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 14.95a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414l-.707.707zm-2.12-10.607a1 1 0 011.414 0l.707.707a1 1 0 11-1.414 1.414l-.707-.707a1 1 0 010-1.414zM4 11a1 1 0 100-2H3a1 1 0 100 2h1z"></path></svg>
-                <svg id="theme-icon-dark" class="w-6 h-6 hidden" fill="currentColor" viewBox="0 0 20 20"><path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path></svg>
+            <div class="profile-actions">
+              <button class="btn btn-secondary" id="new-profile-btn">新增</button>
+              <button class="btn btn-secondary" id="rename-profile-btn">命名</button>
+              <button class="btn btn-secondary" id="import-profile-btn">匯入</button>
+              <button class="btn btn-secondary" id="export-profile-btn">匯出</button>
+              <button class="btn btn-danger-ghost" id="delete-profile-btn" title="刪除">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/></svg>
+              </button>
+            </div>
+            <input type="file" id="profile-file-input" accept=".json" style="display:none" />
+          </div>
+        </div>
+
+        <!-- Tasks -->
+        <div class="section accordion-item active">
+          <button class="section-header accordion-header" data-section="1">
+            <span class="section-num">1</span>
+            <span class="section-title">勤務設定</span>
+            <span class="section-chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+          </button>
+          <div class="section-body">
+            <div class="list-headers task">
+              <span>勤務</span><span>人數</span><span>優先</span><span></span>
+            </div>
+            <div id="task-list"></div>
+
+            <div class="capacity" id="capacity-status">
+              <div class="capacity-head">
+                <span class="capacity-label">本週容量</span>
+                <span class="capacity-numbers"><span id="cap-supply">-</span> / <span class="demand" id="cap-demand">-</span></span>
+              </div>
+              <div class="capacity-bar"><div class="capacity-fill" style="width: 0%"></div></div>
+              <div class="capacity-note" id="cap-note">正在載入...</div>
+            </div>
+
+            <div class="add-row">
+              <input class="input" id="new-task-name" placeholder="新增勤務" />
+              <input class="input num" id="new-task-count" value="1" style="width: 52px;" title="每天需要幾人" />
+              <input class="input num" id="new-task-priority" value="9" style="width: 44px;" title="優先級" />
+              <button class="btn btn-primary btn-iconOnly" id="add-task-btn" title="新增">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Personnel -->
+        <div class="section accordion-item active">
+          <button class="section-header accordion-header" data-section="2">
+            <span class="section-num">2</span>
+            <span class="section-title">人員設定</span>
+            <span class="section-chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+          </button>
+          <div class="section-body">
+            <div class="list-headers personnel">
+              <span>姓名</span><span>上限</span><span></span><span></span><span></span>
+            </div>
+            <div id="personnel-list"></div>
+            <div class="add-row">
+              <input class="input" id="new-personnel-name" placeholder="新增人員姓名" />
+              <button class="btn btn-primary btn-iconOnly" id="add-personnel-btn" title="新增">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Generate -->
+        <div class="section accordion-item active">
+          <button class="section-header accordion-header" data-section="3">
+            <span class="section-num">3</span>
+            <span class="section-title">產生班表</span>
+            <span class="section-chevron"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+          </button>
+          <div class="section-body">
+            <div class="generate-fields">
+              <div class="field">
+                <label class="field-label">開始週</label>
+                <input type="week" class="input" id="start-week" />
+              </div>
+              <div class="field">
+                <label class="field-label">週數</label>
+                <input type="number" class="input num" id="num-weeks" value="1" min="1" max="52" />
+              </div>
+              <div class="field">
+                <label class="field-label">假日設定</label>
+                <button class="holiday-trigger" id="holiday-settings-btn">
+                  <span id="holiday-settings-text">編輯假日選項</span>
+                  <span class="count"></span>
+                </button>
+              </div>
+            </div>
+            <button class="generate-cta" id="generate-schedule">
+              <span id="generate-btn-text">產生智慧班表</span>
+              <span id="generate-spinner" class="cta-spinner hidden"></span>
+              <span class="kbd">⌘ ↵</span>
             </button>
-        </header>
+          </div>
+        </div>
+      </div>
+    </aside>
 
-        <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            <div class="lg:col-span-1 space-y-4">
-                <div id="accordion-container">
-                    <div class="accordion-item card rounded-lg shadow-md">
-                        <button class="accordion-header w-full flex justify-between items-center p-4 text-left font-bold text-lg">
-                            <span>設定檔管理</span>
-                            <svg class="accordion-arrow w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                        </button>
-                        <div class="accordion-content">
-                            <div class="flex items-center gap-2 mb-4">
-                                <label for="profile-select" class="font-medium shrink-0">目前設定檔:</label>
-                                <select id="profile-select" class="form-input rounded-md p-2 w-full"></select>
-                            </div>
-                            <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
-                                <button id="new-profile-btn" class="flex items-center justify-center gap-1 bg-green-500 hover:bg-green-600 text-white font-bold py-2 px-3 rounded-md transition text-sm">新增</button>
-                                <button id="rename-profile-btn" class="flex items-center justify-center gap-1 bg-yellow-500 hover:bg-yellow-600 text-white font-bold py-2 px-3 rounded-md transition text-sm">命名</button>
-                                <button id="delete-profile-btn" class="flex items-center justify-center gap-1 btn-danger text-white font-bold py-2 px-3 rounded-md transition text-sm">刪除</button>
-                                <button id="import-profile-btn" class="flex items-center justify-center gap-1 bg-indigo-500 hover:bg-indigo-600 text-white font-bold py-2 px-3 rounded-md transition text-sm">匯入</button>
-                                <button id="export-profile-btn" class="flex items-center justify-center gap-1 bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-3 rounded-md transition text-sm">匯出</button>
-                            </div>
-                            <input type="file" id="profile-file-input" class="hidden" accept=".json">
-                        </div>
-                    </div>
-                    <div class="accordion-item card rounded-lg shadow-md mt-4">
-                        <button class="accordion-header w-full flex justify-between items-center p-4 text-left font-bold text-lg">
-                            <span>1. 勤務設定</span>
-                            <svg class="accordion-arrow w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                        </button>
-                        <div class="accordion-content">
-                            <div class="space-y-2 mb-3" id="task-list"></div>
-                            <div id="capacity-status" class="text-sm p-2 rounded-md mt-2"></div>
-                            <div class="flex gap-2">
-                                <input type="text" id="new-task-name" class="form-input flex-grow p-2 rounded-md" placeholder="勤務名稱">
-                                <input type="number" id="new-task-count" class="form-input w-20 p-2 rounded-md" placeholder="人數" value="1" min="1" title="每天需要幾人">
-                                <input type="number" id="new-task-priority" class="form-input w-16 p-2 rounded-md text-center" placeholder="優先" value="9" min="1" max="9" title="優先級（1=最優先，9=最低）">
-                                <button id="add-task-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-bold p-2 rounded-md flex-shrink-0">＋</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="accordion-item card rounded-lg shadow-md mt-4">
-                        <button class="accordion-header w-full flex justify-between items-center p-4 text-left font-bold text-lg">
-                            <span>2. 人員設定</span>
-                            <svg class="accordion-arrow w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                        </button>
-                        <div class="accordion-content">
-                            <div class="space-y-2 mb-3" id="personnel-list"></div>
-                            <div class="flex gap-2">
-                                <input type="text" id="new-personnel-name" class="form-input flex-grow p-2 rounded-md" placeholder="人員姓名">
-                                <button id="add-personnel-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-bold p-2 rounded-md flex-shrink-0">＋</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="accordion-item card rounded-lg shadow-md mt-4 active">
-                        <button class="accordion-header w-full flex justify-between items-center p-4 text-left font-bold text-lg">
-                            <span>3. 產生班表</span>
-                            <svg class="accordion-arrow w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
-                        </button>
-                        <div class="accordion-content">
-                            <div class="space-y-4">
-                                <div>
-                                    <label class="block font-medium text-sm text-muted mb-1">選擇開始週</label>
-                                    <input type="week" id="start-week" class="form-input w-full p-2 rounded-md">
-                                </div>
-                                <div>
-                                    <label for="num-weeks" class="block font-medium text-sm text-muted mb-1">產生週數</label>
-                                    <input type="number" id="num-weeks" value="1" min="1" max="10" class="form-input w-full p-2 rounded-md">
-                                </div>
-                                <div>
-                                    <label class="block font-medium text-sm text-muted mb-1">假日排休設定</label>
-                                    <button type="button" id="holiday-settings-btn" class="form-input w-full p-2 rounded-md text-left flex justify-between items-center" aria-expanded="false">
-                                        <span id="holiday-settings-text">編輯假日選項</span>
-                                        <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.096 2.572-1.065z"></path><path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
-                                    </button>
-                                </div>
-                            </div>
-                            <button id="generate-schedule" class="mt-4 w-full text-lg bg-green-600 hover:bg-green-700 text-white font-bold py-3 px-4 rounded-md transition shadow-lg flex items-center justify-center gap-2">
-                                <span id="generate-btn-text">產生智慧班表</span>
-                                <div id="generate-spinner" class="spinner hidden"></div>
-                            </button>
-                        </div>
-                    </div>
-                </div>
+    <!-- ── Right panel ── -->
+    <main>
+
+      <div class="card hidden" id="output-container">
+
+        <div class="panel-head">
+          <div class="panel-title-row">
+            <h2 class="panel-title">班表結果</h2>
+            <button id="conflict-chip" class="conflict-chip" style="display:none">
+              <span class="dot"></span><span id="conflict-count">0</span> 個衝突
+            </button>
+            <div class="seg">
+              <button class="active" id="view-schedule-btn">班表</button>
+              <button id="view-personnel-btn">人員</button>
             </div>
-
-            <div class="lg:col-span-2 space-y-6 min-w-0">
-                <div id="output-container" class="card p-4 rounded-lg shadow-md hidden" style="transition: opacity 0.3s;">
-                    <div class="flex flex-wrap justify-between items-center mb-4 gap-2">
-                        <div class="flex items-center gap-3">
-                            <h2 class="text-2xl font-bold">班表結果</h2>
-                            <div class="flex gap-1 text-sm">
-                                <button id="view-schedule-btn" class="px-3 py-1 rounded bg-blue-600 text-white text-xs">班表</button>
-                                <button id="view-personnel-btn" class="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 text-xs">人員</button>
-                            </div>
-                        </div>
-                        <div class="flex flex-wrap gap-2">
-                            <button id="save-schedule-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-3 rounded-md transition">儲存班表</button>
-                            <button id="copy-schedule" class="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-3 rounded-md transition">複製</button>
-                            <button id="export-excel" class="bg-green-700 hover:bg-green-800 text-white font-bold py-2 px-3 rounded-md transition">Excel</button>
-                            <button id="export-personnel-excel" class="hidden bg-green-700 hover:bg-green-800 text-white font-bold py-2 px-3 rounded-md transition text-sm">人員 Excel</button>
-                            <button id="export-pdf" class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-3 rounded-md transition">PDF（推薦）</button>
-                            <button id="export-image-pdf" class="bg-red-600 hover:bg-red-700 text-white font-bold py-2 px-3 rounded-md transition text-sm">瀏覽器列印</button>
-                        </div>
-                    </div>
-                    <div id="schedule-output" class="overflow-x-auto"></div>
-                    <div id="personnel-view" class="hidden mt-2 overflow-x-auto"></div>
-                    <div id="fill-stats-panel" class="mt-4 hidden"></div>
-                </div>
-
-                <div class="card p-4 rounded-lg shadow-md">
-                    <h2 class="text-xl font-bold mb-3">已儲存的班表</h2>
-                    <ul id="saved-schedules-list" class="list-disc pl-5 space-y-1 text-blue-600 dark:text-blue-400"></ul>
-                </div>
-            </div>
+          </div>
+          <div class="panel-actions">
+            <button class="btn btn-secondary btn-sm" id="enter-edit-btn" style="display:none">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 20h9M16.5 3.5a2.121 2.121 0 113 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
+              編輯班表
+            </button>
+            <button class="btn btn-secondary btn-sm" id="save-schedule-btn">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><path d="M17 21v-8H7v8M7 3v5h8"/></svg>
+              儲存
+            </button>
+            <button class="btn btn-ghost btn-sm" id="copy-schedule">複製</button>
+            <button class="btn btn-ghost btn-sm" id="export-excel">Excel</button>
+            <button class="btn btn-ghost btn-sm" id="export-pdf">PDF</button>
+            <button class="btn btn-ghost btn-sm" id="export-image-pdf">瀏覽器列印</button>
+            <button class="btn btn-ghost btn-sm hidden" id="export-personnel-excel">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><path d="M14 2v6h6M8 13h2l1 2 1-3 1 3 1-2h2"/></svg>
+              人員 Excel
+            </button>
+          </div>
         </div>
 
-        <footer class="text-center mt-8 text-sm text-muted">
-            <div id="status-container" class="flex items-center justify-center gap-2 mb-2" title="正在檢查連線狀態...">
-                <div id="status-indicator" class="w-3 h-3 rounded-full bg-gray-400 transition-colors"></div>
-                <p id="status-text" class="text-xs">正在檢查連線...</p>
-            </div>
-            <p>智慧排班系統 &copy; <span id="footer-year"></span>. All Rights Reserved.</p>
-        </footer>
-    </div>
-
-    <!-- Personnel Modal -->
-    <div id="personnel-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="card p-6 rounded-lg shadow-xl w-11/12 md:w-1/2 max-w-lg mx-auto">
-            <h3 class="text-2xl font-bold mb-4">進階設定: <span id="modal-personnel-name"></span></h3>
-            <div class="mb-4">
-                <label class="block font-medium mb-2">固定排休 (星期幾)</label>
-                <div id="off-days-container" class="flex flex-wrap gap-2"></div>
-            </div>
-            <div class="mb-6">
-                <label for="preferred-task-select" class="block font-medium mb-2">偏好勤務地點</label>
-                <select id="preferred-task-select" class="form-input w-full p-2 rounded-md"></select>
-            </div>
-            <div class="flex justify-end gap-3">
-                <button id="modal-close-btn" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-md transition">關閉</button>
-                <button id="modal-save-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md transition">儲存</button>
-            </div>
+        <div class="edit-toolbar" id="edit-toolbar">
+          <span class="label">編輯模式</span>
+          <span class="meta" id="edit-status"></span>
+          <span class="spacer"></span>
+          <button class="btn btn-ghost btn-sm" id="undo-edit-btn" disabled title="復原 (Ctrl+Z)">復原</button>
+          <button class="btn btn-ghost btn-sm" id="redo-edit-btn" disabled title="重做 (Ctrl+Y)">重做</button>
+          <button class="btn btn-ghost btn-sm" id="diff-btn">變更摘要</button>
+          <button class="btn btn-secondary btn-sm" id="exit-edit-mode-btn">預覽模式</button>
+          <button class="btn btn-ghost btn-sm" id="cancel-edits-btn">取消編輯</button>
+          <button class="btn btn-primary btn-sm" id="save-edits-btn" disabled>儲存修改</button>
         </div>
-    </div>
 
-    <!-- Input Modal -->
-    <div id="input-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="card p-6 rounded-lg shadow-xl w-11/12 max-w-sm mx-auto">
-            <h3 id="input-modal-title" class="text-lg font-bold mb-4"></h3>
-            <input id="input-modal-field" type="text" class="form-input w-full p-2 rounded-md mb-4" />
-            <div class="flex justify-end gap-2">
-                <button id="input-modal-cancel" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-md transition">取消</button>
-                <button id="input-modal-confirm" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md transition">確認</button>
-            </div>
+        <div class="schedule-region" id="schedule-region">
+          <div class="schedule-main">
+            <div class="schedule-area" id="schedule-output"></div>
+            <div id="pv-summary" class="pv-summary" style="display:none"></div>
+            <div class="pv-wrap hidden" id="personnel-view"></div>
+            <div class="pv-legend" id="pv-legend" style="display:none"></div>
+          </div>
+          <aside class="edit-pers-sidebar" id="edit-personnel-sidebar" aria-label="可用人員">
+            <header>
+              <h3>可用人員</h3>
+              <span class="hint">拖拉至格子</span>
+            </header>
+            <div class="drag-list" id="drag-list"></div>
+          </aside>
         </div>
-    </div>
 
-    <!-- Confirm Modal -->
-    <div id="confirm-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="card p-6 rounded-lg shadow-xl w-11/12 max-w-sm mx-auto">
-            <p id="confirm-modal-message" class="text-base mb-6 whitespace-pre-wrap"></p>
-            <div class="flex justify-end gap-2">
-                <button id="confirm-modal-cancel" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-md transition">取消</button>
-                <button id="confirm-modal-ok" class="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded-md transition">確認</button>
-            </div>
+        <div class="fillrate hidden" id="fill-stats-panel">
+          <div class="fillrate-head">
+            <div class="fillrate-title">勤務填補率</div>
+          </div>
+          <div class="fillrate-grid" id="fillrate-grid"></div>
         </div>
-    </div>
 
-    <!-- Holiday Modal -->
-    <div id="holiday-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="card p-6 rounded-lg shadow-xl w-11/12 md:w-1/2 max-w-lg mx-auto">
-            <h3 class="text-2xl font-bold mb-4">假日排休設定</h3>
-            <div id="modal-holiday-list" class="max-h-64 overflow-y-auto space-y-2 border dark:border-gray-600 p-3 rounded-md mb-6"></div>
-            <div class="flex justify-end gap-3">
-                <button id="modal-holiday-close-btn" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded-md transition">關閉</button>
-                <button id="modal-holiday-save-btn" class="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded-md transition">確定</button>
-            </div>
+      </div>
+
+      <div class="card saved">
+        <div class="saved-head">
+          <h3 class="panel-title">已儲存的班表</h3>
         </div>
+        <ul id="saved-schedules-list" class="saved-list"></ul>
+      </div>
+
+      <div class="app-footer">
+        <div>智慧排班系統 v2 · © <span id="footer-year"></span></div>
+        <div>快捷鍵 <span class="kbd">⌘ K</span> <span class="kbd">⌘ ↵</span> <span class="kbd">⌘ Z</span></div>
+      </div>
+
+    </main>
+  </div>
+</div>
+
+<!-- ── Toast container ── -->
+<div class="toast-container" id="toast-container"></div>
+
+<!-- ── Modal: 人員進階設定 ── -->
+<div class="modal-backdrop" id="personnel-modal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="pm-title">
+    <div class="modal-head">
+      <div>
+        <div class="title" id="pm-title">進階設定 · <span id="modal-personnel-name"></span></div>
+        <div class="sub" id="pm-sub">每週上限 <span id="pm-max"></span> 班</div>
+      </div>
+      <button class="modal-close" title="關閉 (Esc)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
     </div>
-
-    <!-- Diff Modal -->
-    <div id="diff-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center hidden z-50">
-        <div class="card p-6 rounded-lg shadow-xl w-11/12 max-w-2xl mx-auto flex flex-col" style="max-height:80vh">
-            <div class="flex justify-between items-center mb-4 shrink-0">
-                <h3 class="text-lg font-bold">與原始班表的差異</h3>
-                <button id="diff-modal-close" class="text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 text-2xl leading-none">&times;</button>
-            </div>
-            <div id="diff-modal-content" class="overflow-y-auto flex-1 text-sm"></div>
-        </div>
+    <div class="modal-body">
+      <div class="modal-section">
+        <div class="modal-section-label">固定排休（星期幾）</div>
+        <div class="dow-row" id="off-days-container"></div>
+      </div>
+      <div class="modal-section">
+        <div class="modal-section-label">偏好勤務地點</div>
+        <select class="select" id="preferred-task-select">
+          <option value="">無偏好</option>
+        </select>
+      </div>
+      <div class="modal-section">
+        <div class="modal-section-label">每週班次上限</div>
+        <input class="input num" id="pm-maxshifts" type="number" min="0" max="5" style="width: 100px;" />
+      </div>
     </div>
-
-    <div id="toast-container" class="fixed bottom-5 right-5 flex flex-col gap-2 z-[9999] pointer-events-none"></div>
-
-    <!-- Tailwind safelist -->
-    <div aria-hidden="true" style="display:none"
-        class="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200
-               bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200
-               bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200
-               bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200
-               bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200
-               bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200
-               bg-white dark:bg-gray-800 bg-gray-50 dark:bg-gray-700 bg-gray-100
-               border-gray-200 dark:border-gray-600
-               bg-amber-50 dark:bg-amber-900 border-amber-300 dark:border-amber-600
-               text-amber-800 dark:text-amber-200
-               text-green-600 dark:text-green-400 text-red-500 dark:text-red-400
-               text-gray-700 dark:text-gray-300 text-gray-500 dark:text-gray-400">
+    <div class="modal-foot">
+      <span class="left" id="pm-hint"><span class="saved-dot"></span>已自動保存</span>
+      <button class="btn btn-secondary" id="modal-close-btn">關閉</button>
+      <button class="btn btn-primary" id="modal-save-btn">儲存</button>
     </div>
+  </div>
+</div>
 
-    <script type="module" src="/src/main.js"></script>
+<!-- ── Modal: 假日排休設定 ── -->
+<div class="modal-backdrop" id="holiday-modal">
+  <div class="modal wide" role="dialog" aria-modal="true" aria-labelledby="hm-title">
+    <div class="modal-head">
+      <div>
+        <div class="title" id="hm-title">假日排休設定</div>
+        <div class="sub">勾選的假日將不排班 · 取消勾選則照常排班</div>
+      </div>
+      <button class="modal-close" title="關閉 (Esc)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <div class="holiday-list" id="modal-holiday-list"></div>
+    </div>
+    <div class="modal-foot">
+      <span class="left" id="hm-hint"><span class="saved-dot"></span><span id="hm-count">0</span> 個假日將排休 · 已自動保存</span>
+      <button class="btn btn-secondary" id="modal-holiday-close-btn">關閉</button>
+      <button class="btn btn-primary" id="modal-holiday-save-btn">完成</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Modal: 通用確認 ── -->
+<div class="modal-backdrop" id="confirm-modal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="cm-title" style="max-width: 420px;">
+    <div class="modal-head">
+      <div>
+        <div class="title" id="cm-title">確認操作</div>
+      </div>
+      <button class="modal-close" title="關閉 (Esc)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <p id="confirm-modal-message" style="margin:0; font-size: 13px; color: var(--text-secondary); line-height: 1.6;"></p>
+    </div>
+    <div class="modal-foot">
+      <span style="flex:1"></span>
+      <button class="btn btn-secondary" id="confirm-modal-cancel">取消</button>
+      <button class="btn btn-primary" id="confirm-modal-ok">確認</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Modal: 通用輸入 ── -->
+<div class="modal-backdrop" id="input-modal">
+  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="im-title" style="max-width: 420px;">
+    <div class="modal-head">
+      <div>
+        <div class="title" id="input-modal-title">輸入</div>
+      </div>
+      <button class="modal-close" title="關閉 (Esc)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body">
+      <label class="field-label" style="display:block; margin-bottom: 8px;">名稱</label>
+      <input class="input" id="input-modal-field" type="text" autocomplete="off" />
+    </div>
+    <div class="modal-foot">
+      <span style="flex:1"></span>
+      <button class="btn btn-secondary" id="input-modal-cancel">取消</button>
+      <button class="btn btn-primary" id="input-modal-confirm">確認</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── Modal: 編輯差異 ── -->
+<div class="modal-backdrop" id="diff-modal">
+  <div class="modal wide" role="dialog" aria-modal="true" aria-labelledby="dm-title">
+    <div class="modal-head">
+      <div>
+        <div class="title" id="dm-title">與原始班表的差異</div>
+        <div class="sub" id="dm-sub">編輯模式 · 共 <span id="dm-total">0</span> 處變動</div>
+      </div>
+      <button class="modal-close" id="diff-modal-close" title="關閉 (Esc)">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+      </button>
+    </div>
+    <div class="modal-body" id="diff-modal-content"></div>
+    <div class="modal-foot">
+      <button class="btn btn-ghost" id="dm-revert">捨棄全部變更</button>
+      <span style="flex:1"></span>
+      <button class="btn btn-secondary" id="diff-modal-close-2">關閉</button>
+      <button class="btn btn-primary" id="diff-modal-apply">套用變更</button>
+    </div>
+  </div>
+</div>
+
+<!-- Tailwind safelist (ensure dynamic classes aren't purged) -->
+<div aria-hidden="true" style="display:none"
+  class="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200
+         bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200
+         bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200
+         bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200
+         bg-pink-100 text-pink-800 dark:bg-pink-900 dark:text-pink-200
+         bg-teal-100 text-teal-800 dark:bg-teal-900 dark:text-teal-200
+         bg-white dark:bg-gray-800 bg-gray-50 dark:bg-gray-700 bg-gray-100
+         border-gray-200 dark:border-gray-600
+         bg-amber-50 dark:bg-amber-900 border-amber-300 dark:border-amber-600
+         text-amber-800 dark:text-amber-200
+         text-green-600 dark:text-green-400 text-red-500 dark:text-red-400
+         text-gray-700 dark:text-gray-300 text-gray-500 dark:text-gray-400">
+</div>
+
+<script type="module" src="/src/main.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1008,6 +1008,22 @@ html.dark .modal-backdrop { background: rgba(0,0,0,.65); }
   100% { transform: scale(1); box-shadow: 0 0 0 0 transparent; }
 }
 
+/* ─── Diff summary modal content ────────────────────────── */
+.diff-empty {
+  text-align: center; padding: 24px 0;
+  font-size: 13px; color: var(--text-muted);
+}
+.diff-item {
+  padding-bottom: 12px; margin-bottom: 12px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.diff-item:last-child { border-bottom: none; margin-bottom: 0; padding-bottom: 0; }
+.diff-label {
+  font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px;
+}
+.diff-added { font-size: 13px; color: var(--success); padding-left: 12px; }
+.diff-removed { font-size: 13px; color: var(--danger); padding-left: 12px; }
+
 .modal-section + .modal-section { margin-top: 18px; }
 .modal-section-label {
   font: 500 10px var(--font-sans);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -636,8 +636,8 @@ body:not(.editing) .edit-toolbar { display: none; }
   font-size: 11px;
 }
 
-/* Person tags inside cells */
-.s-table .editable-cell .persons {
+/* Person tags inside cells (edit and preview) */
+.s-table td .persons {
   display: flex; flex-wrap: wrap; gap: 4px; justify-content: center;
 }
 .person-tag {
@@ -677,6 +677,28 @@ body:not(.editing) .edit-toolbar { display: none; }
 .fillrate-card .bar > div { height: 100%; background: var(--success); }
 .fillrate-card.warn .bar > div { background: var(--warn); }
 .fillrate-card.warn .nums { color: var(--warn); }
+
+/* ─── Weekly stats footer (per-week shift counts) ───────────── */
+.week-footer {
+  margin-top: 12px; padding: 12px 16px;
+  background: var(--bg-inset); border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+}
+.week-footer .wf-title {
+  font-size: 11px; font-weight: 600; color: var(--text-secondary);
+  text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 8px;
+}
+.wf-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+.wf-tag {
+  padding: 2px 10px; border-radius: var(--radius-pill);
+  font-size: 12px; font-weight: 500; border: 1px solid transparent;
+}
+.wf-tag.zero  { background: var(--bg-surface-2); color: var(--text-muted); border-color: var(--border-subtle); }
+.wf-tag.ok    { background: var(--success-soft); color: var(--success); border-color: var(--success-border); }
+.wf-tag.near  { background: var(--warn-soft); color: var(--warn); border-color: var(--warn-border); }
+.wf-tag.full  { background: var(--warn-soft); color: var(--warn); border-color: var(--warn); }
+.wf-tag.over  { background: var(--danger-soft); color: var(--danger); border-color: var(--danger); font-weight: 700; }
+.wf-tag.ghost { background: var(--accent-soft); color: var(--accent-text); border-color: var(--accent-border); font-style: italic; }
 
 /* ─── Saved schedules ───────────────────────────────────────── */
 .saved {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -677,6 +677,33 @@ body:not(.editing) .edit-toolbar { display: none; }
 .fillrate-card .bar > div { height: 100%; background: var(--success); }
 .fillrate-card.warn .bar > div { background: var(--warn); }
 .fillrate-card.warn .nums { color: var(--warn); }
+.fillrate-card.danger .bar > div { background: var(--danger); }
+.fillrate-card.danger .nums { color: var(--danger); }
+
+/* ─── Saved schedules empty state ───────────────────────────── */
+.saved-empty {
+  text-align: center; padding: 12px 0;
+  font-size: 13px; color: var(--text-muted);
+}
+.saved-empty .hint { font-size: 11px; display: block; margin-top: 2px; color: var(--text-faint); }
+
+/* ─── Holiday modal list items ───────────────────────────────── */
+.holiday-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px; border-radius: 6px; cursor: pointer;
+}
+.holiday-item:hover { background: var(--bg-surface-2); }
+.holiday-item .hdate { font-size: 12px; font-family: var(--font-mono); color: var(--text-muted); }
+
+/* ─── Draft restore banner ───────────────────────────────────── */
+.draft-banner {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px; margin-bottom: 14px;
+  background: var(--warn-soft); border: 1px solid var(--warn-border);
+  border-radius: 8px; font-size: 13px;
+}
+.draft-banner .draft-msg { color: var(--warn); flex: 1; }
+.draft-banner .draft-actions { display: flex; gap: 6px; margin-left: 12px; flex-shrink: 0; }
 
 /* ─── Weekly stats footer (per-week shift counts) ───────────── */
 .week-footer {

--- a/frontend/src/features/schedule/diffSummary.js
+++ b/frontend/src/features/schedule/diffSummary.js
@@ -43,17 +43,20 @@ export const showDiffModal = () => {
   if (!original || !current) return;
 
   const changes = buildDiff(original, current);
+  const total = changes.reduce((s, c) => s + c.added.length + c.removed.length, 0);
+  const dmTotal = document.getElementById('dm-total');
+  if (dmTotal) dmTotal.textContent = total;
+
   if (changes.length === 0) {
-    content.innerHTML =
-      '<p class="text-gray-500 dark:text-gray-400 text-center py-6">目前無任何修改，班表與原始一致。</p>';
+    content.innerHTML = '<p class="diff-empty">目前無任何修改，班表與原始一致。</p>';
   } else {
     content.innerHTML = changes
       .map(
         (c) => `
-      <div class="mb-3 pb-3 border-b border-gray-200 dark:border-gray-600 last:border-0">
-        <p class="font-medium text-gray-700 dark:text-gray-300 mb-1">${escapeHtml(c.label)}</p>
-        ${c.added.map((p) => `<p class="text-green-600 dark:text-green-400 ml-3">＋ ${escapeHtml(p)}</p>`).join('')}
-        ${c.removed.map((p) => `<p class="text-red-500 dark:text-red-400 ml-3">－ ${escapeHtml(p)}</p>`).join('')}
+      <div class="diff-item">
+        <p class="diff-label">${escapeHtml(c.label)}</p>
+        ${c.added.map((p) => `<p class="diff-added">＋ ${escapeHtml(p)}</p>`).join('')}
+        ${c.removed.map((p) => `<p class="diff-removed">－ ${escapeHtml(p)}</p>`).join('')}
       </div>`
       )
       .join('');

--- a/frontend/src/features/schedule/diffSummary.js
+++ b/frontend/src/features/schedule/diffSummary.js
@@ -58,5 +58,5 @@ export const showDiffModal = () => {
       )
       .join('');
   }
-  modal.classList.remove('hidden');
+  modal.classList.add('open');
 };

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -78,13 +78,27 @@ const updateCapacityStatus = () => {
   const capacity = (settings.personnel || []).reduce((s, p) => s + (p.maxShifts || 5), 0);
   const demand = (settings.tasks || []).reduce((s, t) => s + (t.count || 1), 0) * 5;
   const diff = capacity - demand;
-  if (!capacity && !demand) { el.textContent = ''; return; }
+
+  // Update redesign capacity panel elements
+  const supplyEl = document.getElementById('cap-supply');
+  const demandEl = document.getElementById('cap-demand');
+  const noteEl = document.getElementById('cap-note');
+  const fillEl = el.querySelector('.capacity-fill');
+  if (supplyEl) supplyEl.textContent = capacity;
+  if (demandEl) demandEl.textContent = demand;
+  if (!capacity && !demand) {
+    if (noteEl) noteEl.textContent = '尚未設定人員或勤務';
+    el.classList.remove('short');
+    return;
+  }
+  const pct = demand > 0 ? Math.min(100, Math.round(capacity / demand * 100)) : 100;
+  if (fillEl) fillEl.style.width = pct + '%';
   if (diff >= 0) {
-    el.className = 'text-sm p-2 rounded-md mt-2 bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-    el.textContent = `容量 ${capacity} ≥ 需求 ${demand}（每週最多可排滿）`;
+    el.classList.remove('short');
+    if (noteEl) noteEl.textContent = `${(settings.personnel || []).length} 位人員可提供 ${capacity} 班次 · 每週需求 ${demand} · 餘 ${diff} 班`;
   } else {
-    el.className = 'text-sm p-2 rounded-md mt-2 bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
-    el.textContent = `容量 ${capacity} < 需求 ${demand}，每週缺少 ${-diff} 個班次，部分勤務將排不滿`;
+    el.classList.add('short');
+    if (noteEl) noteEl.textContent = `容量 ${capacity} < 需求 ${demand}，每週缺少 ${-diff} 個班次，部分勤務將排不滿`;
   }
 };
 
@@ -354,105 +368,44 @@ function renderEditableSchedule() {
   const outputContainer = document.getElementById('output-container');
   if (outputContainer) outputContainer.style.overflow = 'visible';
 
-  const toolbar = createEditToolbar();
-  container.appendChild(toolbar);
-
-  const sidebar = createPersonnelSidebar();
-  const wrapper = document.createElement('div');
-  wrapper.className = 'flex gap-4 items-start';
-  wrapper.style.position = 'static';
-  wrapper.appendChild(sidebar);
-
-  const scheduleContainer = document.createElement('div');
-  scheduleContainer.className = 'flex-1 min-w-0';
-  scheduleContainer.style.overflowX = 'auto';
+  document.body.classList.add('editing');
+  populatePersonnelSidebar();
 
   editingData.forEach((weekData, weekIndex) => {
     const weekElement = createEditableWeek(weekData, weekIndex);
-    scheduleContainer.appendChild(weekElement);
+    container.appendChild(weekElement);
   });
-
-  wrapper.appendChild(scheduleContainer);
-  container.appendChild(wrapper);
 }
 
-function createEditToolbar() {
-  const toolbar = document.createElement('div');
-  toolbar.id = 'edit-toolbar';
-  toolbar.className = 'border rounded-lg p-4 mb-4 flex items-center justify-between';
-  toolbar.innerHTML = `
-    <div class="flex items-center gap-4">
-      <span class="edit-toolbar-label text-blue-700 font-medium">編輯模式</span>
-      <span id="edit-status" class="text-sm text-gray-600"></span>
-    </div>
-    <div class="flex gap-2 flex-wrap">
-      <button id="undo-edit-btn" title="復原 (Ctrl+Z)" disabled class="px-3 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 disabled:opacity-40 text-sm">復原</button>
-      <button id="redo-edit-btn" title="重做 (Ctrl+Y)" disabled class="px-3 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 disabled:opacity-40 text-sm">重做</button>
-      <button id="diff-btn" title="查看與原始班表的差異" class="px-3 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600 text-sm">變更摘要</button>
-      <button id="save-edits-btn" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:bg-gray-400" disabled>儲存修改</button>
-      <button id="cancel-edits-btn" class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600">取消編輯</button>
-      <button id="exit-edit-mode-btn" class="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">預覽模式</button>
-    </div>
-  `;
-
-  setTimeout(() => {
-    document.getElementById('save-edits-btn').addEventListener('click', saveEdits);
-    document.getElementById('cancel-edits-btn').addEventListener('click', cancelEdits);
-    document.getElementById('exit-edit-mode-btn').addEventListener('click', exitEditMode);
-    document.getElementById('undo-edit-btn').addEventListener('click', () =>
-      undoEdit(renderEditableSchedule)
-    );
-    document.getElementById('redo-edit-btn').addEventListener('click', () =>
-      redoEdit(renderEditableSchedule)
-    );
-    document.getElementById('diff-btn').addEventListener('click', showDiffModal);
-  }, 0);
-
-  return toolbar;
+function initEditToolbarEvents() {
+  document.getElementById('save-edits-btn')?.addEventListener('click', saveEdits);
+  document.getElementById('cancel-edits-btn')?.addEventListener('click', cancelEdits);
+  document.getElementById('exit-edit-mode-btn')?.addEventListener('click', exitEditMode);
+  document.getElementById('undo-edit-btn')?.addEventListener('click', () =>
+    undoEdit(renderEditableSchedule)
+  );
+  document.getElementById('redo-edit-btn')?.addEventListener('click', () =>
+    redoEdit(renderEditableSchedule)
+  );
+  document.getElementById('diff-btn')?.addEventListener('click', showDiffModal);
 }
 
-function createPersonnelSidebar() {
-  const sidebar = document.createElement('div');
-  sidebar.id = 'edit-personnel-sidebar';
-  sidebar.className = 'w-64 bg-gray-50 border border-gray-200 rounded-lg p-4';
-  sidebar.style.position = 'sticky';
-  sidebar.style.top = '20px';
-  sidebar.style.alignSelf = 'flex-start';
-  sidebar.style.maxHeight = 'calc(100vh - 40px)';
-  sidebar.style.display = 'flex';
-  sidebar.style.flexDirection = 'column';
-  sidebar.style.overflow = 'hidden';
-
-  const header = document.createElement('h3');
-  header.className = 'font-bold mb-3 text-gray-700';
-  header.textContent = '可用人員';
-  header.style.flexShrink = '0';
-  sidebar.appendChild(header);
-
-  const personnelList = document.createElement('div');
-  personnelList.className = 'space-y-2';
-  personnelList.style.flex = '1';
-  personnelList.style.overflowY = 'auto';
-  personnelList.style.overflowX = 'hidden';
-  personnelList.style.paddingRight = '8px';
-  personnelList.style.paddingBottom = '16px';
-  personnelList.style.minHeight = '0';
+function populatePersonnelSidebar() {
+  const dragList = document.getElementById('drag-list');
+  if (!dragList) return;
+  dragList.innerHTML = '';
 
   const personnel = getActiveProfile().settings.personnel || [];
   personnel.forEach((person) => {
-    const personElement = document.createElement('div');
-    personElement.className =
-      'bg-white border border-gray-300 rounded px-3 py-2 cursor-move hover:bg-blue-50 hover:border-blue-400 transition-colors';
-    personElement.draggable = true;
-    personElement.textContent = person.name;
-    personElement.dataset.personName = person.name;
-    personElement.addEventListener('dragstart', handlePersonDragStart);
-    personElement.addEventListener('dragend', handlePersonDragEnd);
-    personnelList.appendChild(personElement);
+    const card = document.createElement('div');
+    card.className = 'drag-card';
+    card.draggable = true;
+    card.textContent = person.name;
+    card.dataset.personName = person.name;
+    card.addEventListener('dragstart', handlePersonDragStart);
+    card.addEventListener('dragend', handlePersonDragEnd);
+    dragList.appendChild(card);
   });
-
-  sidebar.appendChild(personnelList);
-  return sidebar;
 }
 
 function createEditableWeek(weekData, weekIndex) {
@@ -1081,6 +1034,9 @@ async function exitEditMode() {
   setHasUnsavedChanges(false);
   draggedPerson = null;
   draggedFromCell = null;
+  document.body.classList.remove('editing');
+  const dragList = document.getElementById('drag-list');
+  if (dragList) dragList.innerHTML = '';
 
   api.post('render-schedule', getGeneratedData()).then((response) => {
     if (response?.html) {
@@ -1118,11 +1074,11 @@ const openPersonnelModal = (index) => {
           `<option value="${task.name}" ${person.preferredTask === task.name ? 'selected' : ''}>${task.name}</option>`
       )
       .join('');
-  elements.personnelModal.classList.remove('hidden');
+  elements.personnelModal.classList.add('open');
 };
 
 const closePersonnelModal = () => {
-  elements.personnelModal.classList.add('hidden');
+  elements.personnelModal.classList.remove('open');
   currentEditingPersonnelIndex = -1;
 };
 
@@ -1582,18 +1538,18 @@ document.addEventListener('DOMContentLoaded', async () => {
       </label>`
       )
       .join('');
-    elements.holidayModal.classList.remove('hidden');
+    elements.holidayModal.classList.add('open');
   });
 
   elements.modalHolidayCloseBtn.addEventListener('click', () => {
-    elements.holidayModal.classList.add('hidden');
+    elements.holidayModal.classList.remove('open');
   });
 
   elements.modalHolidaySaveBtn.addEventListener('click', () => {
     const checkedBoxes = elements.modalHolidayList.querySelectorAll('.holiday-checkbox:checked');
     activeHolidayDates = new Set(Array.from(checkedBoxes).map((cb) => cb.value));
     updateHolidayButtonText();
-    elements.holidayModal.classList.add('hidden');
+    elements.holidayModal.classList.remove('open');
     if (getGeneratedData()) {
       elements.outputContainer.style.opacity = '0.5';
       generateFullSchedule().then(() => {
@@ -1606,8 +1562,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   elements.numWeeksInput.addEventListener('input', debouncedUpdateHolidays);
 
   document.getElementById('diff-modal-close')?.addEventListener('click', () => {
-    document.getElementById('diff-modal').classList.add('hidden');
+    document.getElementById('diff-modal').classList.remove('open');
   });
+
+  initEditToolbarEvents();
 
   // 人員/班表 tab 切換
   const personnelExcelBtn = document.getElementById('export-personnel-excel');
@@ -1616,10 +1574,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   document.getElementById('view-schedule-btn')?.addEventListener('click', () => {
     document.getElementById('schedule-output').classList.remove('hidden');
     document.getElementById('personnel-view').classList.add('hidden');
-    document.getElementById('view-schedule-btn').className =
-      'px-3 py-1 rounded bg-blue-600 text-white text-xs';
-    document.getElementById('view-personnel-btn').className =
-      'px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 text-xs';
+    document.getElementById('view-schedule-btn').className = 'active';
+    document.getElementById('view-personnel-btn').className = '';
     scheduleExcelBtn?.classList.remove('hidden');
     personnelExcelBtn?.classList.add('hidden');
   });
@@ -1628,10 +1584,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     renderPersonnelView(getEditingData() || getGeneratedData());
     document.getElementById('personnel-view').classList.remove('hidden');
     document.getElementById('schedule-output').classList.add('hidden');
-    document.getElementById('view-personnel-btn').className =
-      'px-3 py-1 rounded bg-blue-600 text-white text-xs';
-    document.getElementById('view-schedule-btn').className =
-      'px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600 text-xs';
+    document.getElementById('view-personnel-btn').className = 'active';
+    document.getElementById('view-schedule-btn').className = '';
     scheduleExcelBtn?.classList.add('hidden');
     personnelExcelBtn?.classList.remove('hidden');
   });

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -171,7 +171,7 @@ const renderSavedSchedules = () => {
   const scheduleNames = schedules ? Object.keys(schedules) : [];
   if (scheduleNames.length === 0) {
     elements.savedSchedulesList.innerHTML =
-      '<li class="text-gray-400 dark:text-gray-500 text-center py-3 text-sm">尚無儲存的班表<br><span class="text-xs">產生班表後點擊「儲存班表」</span></li>';
+      '<li class="saved-empty">尚無儲存的班表<span class="hint">產生班表後點擊「儲存班表」</span></li>';
     return;
   }
   elements.savedSchedulesList.innerHTML = '';
@@ -261,7 +261,9 @@ const updateHolidaySelectionUI = async () => {
 // ─────────────────────────────────────────────
 const renderFillStats = (weekData) => {
   const panel = document.getElementById('fill-stats-panel');
-  if (!panel) return;
+  const grid = document.getElementById('fillrate-grid');
+  if (!panel || !grid) return;
+
   const statsMap = {};
   for (const week of weekData) {
     for (const s of week.fillStats || []) {
@@ -270,29 +272,23 @@ const renderFillStats = (weekData) => {
       statsMap[s.name].filled += s.filled;
     }
   }
+
   const names = Object.keys(statsMap);
   if (names.length === 0) { panel.classList.add('hidden'); return; }
-  const allOk = names.every((n) => statsMap[n].filled === statsMap[n].needed);
-  if (allOk) {
-    panel.className = 'mt-4 text-sm p-2 rounded-md bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-    panel.textContent = '所有勤務已排滿';
-    return;
-  }
-  const rows = names
-    .map((n) => {
-      const s = statsMap[n];
-      const pct = s.needed > 0 ? Math.round((s.filled / s.needed) * 100) : 100;
-      const color =
-        pct === 100
-          ? 'text-green-700 dark:text-green-300'
-          : pct >= 50
-          ? 'text-yellow-700 dark:text-yellow-300'
-          : 'text-red-700 dark:text-red-300';
-      return `<tr class="${color}"><td class="pr-3 py-0.5">${escapeHtml(n)}</td><td class="pr-3">優先 ${s.priority}</td><td class="pr-3">${s.filled} / ${s.needed}</td><td>${pct}%</td></tr>`;
-    })
-    .join('');
-  panel.className = 'mt-4';
-  panel.innerHTML = `<p class="text-sm font-semibold mb-1">勤務填補率</p><table class="text-sm"><thead><tr class="text-muted"><th class="pr-3 text-left font-normal">勤務</th><th class="pr-3 text-left font-normal">優先級</th><th class="pr-3 text-left font-normal">填補/需求</th><th class="text-left font-normal">填補率</th></tr></thead><tbody>${rows}</tbody></table>`;
+
+  panel.className = 'fillrate';
+
+  grid.innerHTML = names.map((n) => {
+    const s = statsMap[n];
+    const pct = s.needed > 0 ? Math.round((s.filled / s.needed) * 100) : 100;
+    const mod = pct === 100 ? '' : pct >= 50 ? ' warn' : ' danger';
+    return `
+    <div class="fillrate-card${mod}">
+      <div><span class="name">${escapeHtml(n)}</span><span class="pri">優先 ${s.priority}</span></div>
+      <div class="nums">${s.filled}/${s.needed} · ${pct}%</div>
+      <div class="bar"><div style="width:${Math.min(pct, 100)}%"></div></div>
+    </div>`;
+  }).join('');
 };
 
 async function generateFullSchedule() {
@@ -1527,10 +1523,10 @@ document.addEventListener('DOMContentLoaded', async () => {
     elements.modalHolidayList.innerHTML = availableHolidays
       .map(
         (holiday) => `
-      <label class="flex items-center space-x-2 p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded cursor-pointer">
-        <input type="checkbox" class="form-checkbox rounded holiday-checkbox" value="${holiday.date}" ${activeHolidayDates.has(holiday.date) ? 'checked' : ''}>
-        <span class="flex-grow">${holiday.name}</span>
-        <span class="text-sm text-gray-500">(${holiday.date.substring(4, 6)}/${holiday.date.substring(6, 8)})</span>
+      <label class="holiday-item">
+        <input type="checkbox" class="holiday-checkbox" value="${holiday.date}" ${activeHolidayDates.has(holiday.date) ? 'checked' : ''}>
+        <span style="flex:1">${holiday.name}</span>
+        <span class="hdate">${holiday.date.substring(4, 6)}/${holiday.date.substring(6, 8)}</span>
       </label>`
       )
       .join('');

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -409,35 +409,47 @@ function populatePersonnelSidebar() {
 }
 
 function createEditableWeek(weekData, weekIndex) {
-  const { schedule, tasks, dateRange, weekDayDates, scheduleDays, color } = weekData;
+  const { schedule, tasks, dateRange, weekDayDates, scheduleDays } = weekData;
   const weekDayNames = ['一', '二', '三', '四', '五'];
 
+  // 計算填補率用於 week-head
+  const workDays = scheduleDays.filter(d => d.shouldSchedule).length;
+  const demand = tasks.reduce((s, t) => s + t.count, 0) * workDays;
+  const filled = tasks.reduce((s, task, ti) =>
+    s + scheduleDays.reduce((a, day, di) =>
+      a + (day.shouldSchedule ? schedule[di][ti].length : 0), 0), 0);
+  const pct = demand > 0 ? Math.round(filled / demand * 100) : 100;
+  const fillClass = pct >= 100 ? 'ok' : 'warn';
+
   const weekDiv = document.createElement('div');
-  weekDiv.className = 'mb-8';
+  weekDiv.className = 'week-block';
   weekDiv.id = `schedule-week-${weekIndex}`;
 
-  const title = document.createElement('h3');
-  title.className = 'text-xl font-bold mb-2';
-  title.textContent = `第 ${weekIndex + 1} 週班表 (${dateRange})`;
-  weekDiv.appendChild(title);
+  const weekHead = document.createElement('div');
+  weekHead.className = 'week-head';
+  weekHead.innerHTML = `
+    <div class="week-label">
+      <span class="week-num">W${weekIndex + 1}</span>
+      <span class="week-date">${dateRange}</span>
+    </div>
+    <div class="week-stats">填補 <span class="${fillClass}">${filled}/${demand}</span> · ${pct}%</div>`;
+  weekDiv.appendChild(weekHead);
 
   const table = document.createElement('table');
-  table.className = 'schedule-table w-full border-collapse';
+  table.className = 's-table';
 
   const thead = document.createElement('thead');
   const headerRow = document.createElement('tr');
 
   const thTask = document.createElement('th');
-  thTask.style.backgroundColor = color.header;
-  thTask.style.color = 'white';
-  thTask.textContent = '勤務地點';
+  thTask.style.textAlign = 'left';
+  thTask.style.paddingLeft = '16px';
+  thTask.textContent = '勤務';
   headerRow.appendChild(thTask);
 
   weekDayDates.forEach((date, dayIndex) => {
     const th = document.createElement('th');
-    th.style.backgroundColor = color.header;
-    th.style.color = 'white';
-    th.innerHTML = `星期${weekDayNames[dayIndex]}<br>(${date})`;
+    th.innerHTML = `<span class="dow">星期${weekDayNames[dayIndex]}</span><span class="date">${date}</span>`;
     headerRow.appendChild(th);
   });
 
@@ -449,20 +461,19 @@ function createEditableWeek(weekData, weekIndex) {
     const row = document.createElement('tr');
 
     const tdTask = document.createElement('td');
-    tdTask.className = 'font-medium align-middle bg-gray-50';
-    tdTask.textContent = task.name;
+    tdTask.className = 'task-cell';
+    const priorityCls = `p${task.priority || 9}`;
+    tdTask.innerHTML = `<span class="priority-dot ${priorityCls}"></span>${task.name}<span class="task-meta">需 ${task.count} · P${task.priority || 9}</span>`;
     row.appendChild(tdTask);
 
     weekDayDates.forEach((date, dayIndex) => {
       const td = document.createElement('td');
-      td.className = 'align-middle p-2 border border-gray-300 min-h-[60px]';
 
       if (!scheduleDays[dayIndex].shouldSchedule) {
-        td.classList.add('holiday-cell');
-        td.textContent = scheduleDays[dayIndex].description;
+        td.className = 'holiday-cell';
+        td.innerHTML = `<span class="holiday-label">${scheduleDays[dayIndex].description}</span>`;
       } else {
-        td.classList.add('editable-cell', 'hover:bg-blue-50', 'cursor-pointer');
-        td.style.position = 'relative';
+        td.className = 'editable-cell';
         td.dataset.weekIndex = weekIndex;
         td.dataset.dayIndex = dayIndex;
         td.dataset.taskIndex = taskIndex;
@@ -489,19 +500,18 @@ function createEditableWeek(weekData, weekIndex) {
   table.appendChild(tbody);
   weekDiv.appendChild(table);
 
-  const statsDiv = createWeeklyStats(weekData, weekIndex);
+  const statsDiv = createWeeklyStats(weekData);
   weekDiv.appendChild(statsDiv);
 
   return weekDiv;
 }
 
-function createWeeklyStats(weekData, weekIndex) {
+function createWeeklyStats(weekData) {
   const { schedule } = weekData;
   const personnel = getActiveProfile().settings.personnel || [];
 
   const shiftCounts = {};
   personnel.forEach((person) => { shiftCounts[person.name] = 0; });
-
   schedule.forEach((daySchedule) => {
     daySchedule.forEach((taskPersonnel) => {
       taskPersonnel.forEach((personName) => {
@@ -510,60 +520,51 @@ function createWeeklyStats(weekData, weekIndex) {
     });
   });
 
-  const statsContainer = document.createElement('div');
-  statsContainer.className = 'mt-3 p-3 bg-gray-50 rounded-lg border border-gray-200 weekly-stats-card';
+  const container = document.createElement('div');
+  container.className = 'week-footer';
 
   const title = document.createElement('div');
-  title.className = 'font-semibold text-gray-700 mb-2 text-sm';
-  title.textContent = '本週值勤次數統計';
-  statsContainer.appendChild(title);
+  title.className = 'wf-title';
+  title.textContent = '本週值勤次數';
+  container.appendChild(title);
 
-  const tagsContainer = document.createElement('div');
-  tagsContainer.className = 'flex flex-wrap gap-2';
+  const tags = document.createElement('div');
+  tags.className = 'wf-tags';
 
   personnel.forEach((person) => {
     const count = shiftCounts[person.name] || 0;
     const maxShifts = person.maxShifts || 5;
-    const tag = document.createElement('div');
-    tag.className = 'px-3 py-1 rounded-full text-sm font-medium';
-    if (count === 0) {
-      tag.className += ' bg-gray-200 text-gray-600';
-    } else if (count > maxShifts) {
-      tag.className += ' bg-red-100 text-red-700 border-2 border-red-400';
-      tag.textContent = `${person.name}: ${count}/${maxShifts}`;
-    } else if (count === maxShifts) {
-      tag.className += ' bg-orange-100 text-orange-700';
-    } else if (count >= maxShifts - 1) {
-      tag.className += ' bg-yellow-100 text-yellow-700';
-    } else {
-      tag.className += ' bg-green-100 text-green-700';
-    }
-    if (!tag.textContent) tag.textContent = `${person.name}: ${count}/${maxShifts}`;
-    tagsContainer.appendChild(tag);
+    const tag = document.createElement('span');
+    let stateClass = 'ok';
+    if (count === 0) stateClass = 'zero';
+    else if (count > maxShifts) stateClass = 'over';
+    else if (count === maxShifts) stateClass = 'full';
+    else if (count >= maxShifts - 1) stateClass = 'near';
+    tag.className = `wf-tag ${stateClass}`;
+    tag.textContent = `${person.name}: ${count}/${maxShifts}`;
+    tags.appendChild(tag);
   });
 
   Object.keys(shiftCounts).forEach((personName) => {
-    const isInCurrentList = personnel.some((p) => p.name === personName);
-    if (!isInCurrentList) {
+    if (!personnel.some((p) => p.name === personName)) {
       const count = shiftCounts[personName];
-      const tag = document.createElement('div');
-      tag.className =
-        'px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-700 border border-purple-300';
+      const tag = document.createElement('span');
+      tag.className = 'wf-tag ghost';
       tag.textContent = `${personName}: ${count} (已刪除)`;
-      tagsContainer.appendChild(tag);
+      tags.appendChild(tag);
     }
   });
 
-  statsContainer.appendChild(tagsContainer);
-  return statsContainer;
+  container.appendChild(tags);
+  return container;
 }
 
 function updateWeeklyStats(weekIndex) {
   const weekElement = document.getElementById(`schedule-week-${weekIndex}`);
   if (!weekElement) return;
-  const oldStats = weekElement.querySelector('.mt-3.p-3.bg-gray-50');
+  const oldStats = weekElement.querySelector('.week-footer');
   if (oldStats) oldStats.remove();
-  const statsDiv = createWeeklyStats(getEditingData()[weekIndex], weekIndex);
+  const statsDiv = createWeeklyStats(getEditingData()[weekIndex]);
   weekElement.appendChild(statsDiv);
 }
 
@@ -580,44 +581,40 @@ function renderCellPersonnel(cell, personnelList) {
   const taskRequiredCount = editingData[weekIndex].tasks[taskIndex].count;
   const currentCount = personnelList.length;
 
-  const container = document.createElement('div');
-  container.className = 'flex flex-col gap-1';
-
-  const countIndicator = document.createElement('div');
-  countIndicator.className = 'text-xs font-semibold';
+  // 缺/滿/超額 小指示器
+  const countEl = document.createElement('div');
+  countEl.style.cssText = 'font:500 10px var(--font-mono);margin-bottom:4px;';
   if (currentCount < taskRequiredCount) {
-    countIndicator.className += ' text-orange-600';
-    countIndicator.textContent = `${currentCount}/${taskRequiredCount} (缺 ${taskRequiredCount - currentCount})`;
-  } else if (currentCount === taskRequiredCount) {
-    countIndicator.className += ' text-green-600';
-    countIndicator.textContent = `${currentCount}/${taskRequiredCount} ✓`;
+    countEl.style.color = 'var(--warn)';
+    countEl.textContent = `${currentCount}/${taskRequiredCount} ✗`;
+    cell.classList.add('warn-cell');
   } else {
-    countIndicator.className += ' text-red-600';
-    countIndicator.textContent = `${currentCount}/${taskRequiredCount} (超額)`;
+    countEl.style.color = 'var(--success)';
+    countEl.textContent = `${currentCount}/${taskRequiredCount} ✓`;
+    cell.classList.remove('warn-cell');
   }
-  container.appendChild(countIndicator);
+  cell.appendChild(countEl);
 
-  const personnelContainer = document.createElement('div');
-  personnelContainer.className = 'flex flex-wrap gap-1';
+  const persons = document.createElement('div');
+  persons.className = 'persons';
 
   personnelList.forEach((personName, index) => {
     const tag = document.createElement('span');
-    tag.className =
-      'person-tag inline-block bg-blue-100 text-blue-800 px-2 py-1 rounded-full text-sm cursor-move';
+    tag.className = 'person-tag';
     tag.draggable = true;
+    tag.dataset.personName = personName;
+    tag.dataset.personIndex = index;
 
     const nameSpan = document.createElement('span');
     nameSpan.textContent = personName;
     tag.appendChild(nameSpan);
 
     const removeBtn = document.createElement('button');
-    removeBtn.className = 'remove-person ml-1 text-red-600 hover:text-red-800 font-bold';
+    removeBtn.className = 'remove-person';
+    removeBtn.style.cssText = 'color:var(--danger);font-weight:700;margin-left:2px;font-size:13px;line-height:1;';
     removeBtn.textContent = '×';
     removeBtn.draggable = false;
     tag.appendChild(removeBtn);
-
-    tag.dataset.personName = personName;
-    tag.dataset.personIndex = index;
 
     tag.addEventListener('dragstart', handleTagDragStart);
     tag.addEventListener('dragend', handlePersonDragEnd);
@@ -632,18 +629,17 @@ function renderCellPersonnel(cell, personnelList) {
     });
     removeBtn.addEventListener('mousedown', (e) => e.stopPropagation());
 
-    personnelContainer.appendChild(tag);
+    persons.appendChild(tag);
   });
 
   if (personnelList.length === 0) {
     const placeholder = document.createElement('span');
-    placeholder.className = 'text-gray-400 text-sm';
-    placeholder.textContent = '點擊選擇或拖拽人員';
-    personnelContainer.appendChild(placeholder);
+    placeholder.className = 'person-tag unfilled';
+    placeholder.textContent = '＋ 待補';
+    persons.appendChild(placeholder);
   }
 
-  container.appendChild(personnelContainer);
-  cell.appendChild(container);
+  cell.appendChild(persons);
 
   requestAnimationFrame(() => requestAnimationFrame(() => window.scrollTo(scrollX, scrollY)));
 }

--- a/frontend/src/state/draftManager.js
+++ b/frontend/src/state/draftManager.js
@@ -55,13 +55,12 @@ export const showDraftBanner = (draft, mins, renderEditableScheduleCallback) => 
   const label = mins < 1 ? '剛才' : `${mins} 分鐘前`;
   const banner = document.createElement('div');
   banner.id = 'draft-banner';
-  banner.className =
-    'mb-4 p-3 bg-amber-50 dark:bg-amber-900 border border-amber-300 dark:border-amber-600 rounded-lg flex items-center justify-between text-sm';
+  banner.className = 'draft-banner';
   banner.innerHTML = `
-    <span class="text-amber-800 dark:text-amber-200">找到 ${label} 的未儲存草稿（設定檔：${escapeHtml(draft.profile)}）</span>
-    <div class="flex gap-2 ml-3 shrink-0">
-      <button id="draft-restore-btn" class="bg-amber-500 hover:bg-amber-600 text-white px-3 py-1 rounded text-xs">恢復草稿</button>
-      <button id="draft-discard-btn" class="bg-gray-400 hover:bg-gray-500 text-white px-3 py-1 rounded text-xs">捨棄</button>
+    <span class="draft-msg">找到 ${label} 的未儲存草稿（設定檔：${escapeHtml(draft.profile)}）</span>
+    <div class="draft-actions">
+      <button id="draft-restore-btn" class="btn btn-primary btn-sm">恢復草稿</button>
+      <button id="draft-discard-btn" class="btn btn-ghost btn-sm">捨棄</button>
     </div>`;
 
   const container = document.getElementById('output-container');

--- a/frontend/src/ui/modal.js
+++ b/frontend/src/ui/modal.js
@@ -9,7 +9,7 @@ export const showInput = (title, defaultValue = '') => {
     document.getElementById('input-modal-title').textContent = title;
     const field = document.getElementById('input-modal-field');
     field.value = defaultValue;
-    document.getElementById('input-modal').classList.remove('hidden');
+    document.getElementById('input-modal').classList.add('open');
     setTimeout(() => {
       field.focus();
       field.select();
@@ -29,7 +29,7 @@ export const showInput = (title, defaultValue = '') => {
     };
 
     function cleanup() {
-      document.getElementById('input-modal').classList.add('hidden');
+      document.getElementById('input-modal').classList.remove('open');
       document.getElementById('input-modal-confirm').removeEventListener('click', onConfirm);
       document.getElementById('input-modal-cancel').removeEventListener('click', onCancel);
       field.removeEventListener('keydown', onKeydown);
@@ -49,7 +49,7 @@ export const showInput = (title, defaultValue = '') => {
 export const showConfirm = (message) => {
   return new Promise((resolve) => {
     document.getElementById('confirm-modal-message').textContent = message;
-    document.getElementById('confirm-modal').classList.remove('hidden');
+    document.getElementById('confirm-modal').classList.add('open');
 
     const onOk = () => {
       cleanup();
@@ -61,7 +61,7 @@ export const showConfirm = (message) => {
     };
 
     function cleanup() {
-      document.getElementById('confirm-modal').classList.add('hidden');
+      document.getElementById('confirm-modal').classList.remove('open');
       document.getElementById('confirm-modal-ok').removeEventListener('click', onOk);
       document.getElementById('confirm-modal-cancel').removeEventListener('click', onCancel);
     }


### PR DESCRIPTION
## Summary

73 個 commit，涵蓋以下四大塊：

**UI / 深色模式**
- 編輯模式與預覽模式統一使用設計稿 CSS 類別（`.week-block` / `.s-table` / `.task-cell` / `.person-tag`）
- 移除前端所有動態 innerHTML 中的 `dark:` Tailwind variant（CDN 不編譯動態 class）
- `scheduleRenderer.js` 重寫為設計 CSS 結構，預覽/列印視覺與編輯模式一致
- 填補率面板、週次統計、草稿橫幅、變更摘要 Modal 深色模式全部修正
- 修正編輯模式 5 項 bug（重複 ID、儲存按鈕無效、`body.editing` 未設定等）

**學校行事曆**
- 段考改名為一段/二段/期末考
- MongoDB 7 天持久快取，避免重啟後重抓
- 新增 `POST /api/school-events/refresh` 強制刷新端點
- 新增路由測試

**基礎建設**
- 新增 Dockerfile（多階段 build，production 模式 serve 靜態檔）
- `holidays/` 目錄納入 Docker image，修正 reseed count=0
- reseed 改從 CDN 抓取，不依賴本地 JSON

**測試**
- 後端 143 個測試全數通過
- E2E 修復多項 CI 超時問題

## Test plan

- [x] `cd backend && npm test` → 143/143 通過
- [x] 產生班表 → 編輯模式 → 深色模式視覺正常
- [x] 切「預覽模式」→ 班表樣式一致
- [x] 填補率、週次統計、變更摘要 Modal 深色模式正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)